### PR TITLE
feat: 결제 기능 구현

### DIFF
--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -4,6 +4,7 @@ import com.gugucon.shopping.pay.domain.Pay;
 import com.gugucon.shopping.pay.dto.PayRequest;
 import com.gugucon.shopping.pay.dto.PayResponse;
 import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
 import com.gugucon.shopping.pay.infrastructure.TossPayValidator;
 import com.gugucon.shopping.pay.repository.PayRepository;
 import org.springframework.stereotype.Service;
@@ -15,22 +16,31 @@ public class PayService {
 
     private final PayRepository payRepository;
     private final TossPayValidator tossPayValidator;
+    private final OrderIdTranslator orderIdTranslator;
 
-    public PayService(final PayRepository payRepository, final TossPayValidator tossPayValidator) {
+    public PayService(final PayRepository payRepository,
+                      final TossPayValidator tossPayValidator,
+                      final OrderIdTranslator orderIdTranslator) {
         this.payRepository = payRepository;
         this.tossPayValidator = tossPayValidator;
+        this.orderIdTranslator = orderIdTranslator;
     }
 
     @Transactional
     public PayResponse createPay(final PayRequest payRequest) {
         // TODO: 결제 금액이 실제 주문 금액과 같은지 확인
-        final Pay pay = new Pay(payRequest.getOrderId(), payRequest.getOrderName(), payRequest.getPrice());
+        Long orderId = payRequest.getOrderId();
+        String orderName = payRequest.getOrderName();
+        Long price = payRequest.getPrice();
+        final String encodedOrderId = orderIdTranslator.encode(orderId, orderName);
+        final Pay pay = new Pay(orderId, orderName, encodedOrderId, price);
         return payRepository.save(pay)
                 .toPayResponse();
     }
 
     public void validatePay(final PaySuccessParameter paySuccessParameter) {
-        final Pay pay = payRepository.findByEncodedOrderId(paySuccessParameter.getOrderId())
+        Long orderId = orderIdTranslator.decode(paySuccessParameter.getOrderId());
+        final Pay pay = payRepository.findByOrderId(orderId)
                                .orElseThrow(RuntimeException::new);
         pay.validateMoney(paySuccessParameter.getPrice());
         tossPayValidator.validatePayment(paySuccessParameter);

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -3,7 +3,7 @@ package com.gugucon.shopping.pay.application;
 import com.gugucon.shopping.pay.domain.Pay;
 import com.gugucon.shopping.pay.dto.PayRequest;
 import com.gugucon.shopping.pay.dto.PayResponse;
-import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
 import com.gugucon.shopping.pay.infrastructure.TossPayValidator;
 import com.gugucon.shopping.pay.repository.PayRepository;
@@ -42,11 +42,11 @@ public class PayService {
         return PayResponse.of(payRepository.save(pay));
     }
 
-    public void validatePay(final PaySuccessParameter paySuccessParameter) {
-        Long orderId = orderIdTranslator.decode(paySuccessParameter.getOrderId());
+    public void validatePay(final PayValidationRequest payValidationRequest) {
+        Long orderId = orderIdTranslator.decode(payValidationRequest.getOrderId());
         final Pay pay = payRepository.findByOrderId(orderId)
                                .orElseThrow(RuntimeException::new);
-        pay.validateMoney(paySuccessParameter.getAmount());
-        tossPayValidator.validatePayment(paySuccessParameter);
+        pay.validateMoney(payValidationRequest.getAmount());
+        tossPayValidator.validatePayment(payValidationRequest);
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -46,7 +46,7 @@ public class PayService {
         Long orderId = orderIdTranslator.decode(paySuccessParameter.getOrderId());
         final Pay pay = payRepository.findByOrderId(orderId)
                                .orElseThrow(RuntimeException::new);
-        pay.validateMoney(paySuccessParameter.getPrice());
+        pay.validateMoney(paySuccessParameter.getAmount());
         tossPayValidator.validatePayment(paySuccessParameter);
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -1,0 +1,27 @@
+package com.gugucon.shopping.pay.application;
+
+import com.gugucon.shopping.pay.domain.Pay;
+import com.gugucon.shopping.pay.dto.PayRequest;
+import com.gugucon.shopping.pay.dto.PayResponse;
+import com.gugucon.shopping.pay.repository.PayRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class PayService {
+
+    private final PayRepository payRepository;
+
+    public PayService(PayRepository payRepository) {
+        this.payRepository = payRepository;
+    }
+
+    @Transactional
+    public PayResponse createPay(PayRequest payRequest) {
+        // TODO: 결제 금액이 실제 주문 금액과 같은지 확인
+        final Pay pay = new Pay(payRequest.getOrderId(), payRequest.getPrice());
+        return payRepository.save(pay)
+                .toPayResponse();
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -29,13 +29,17 @@ public class PayService {
     @Transactional
     public PayResponse createPay(final PayRequest payRequest) {
         // TODO: 결제 금액이 실제 주문 금액과 같은지 확인
-        Long orderId = payRequest.getOrderId();
-        String orderName = payRequest.getOrderName();
-        Long price = payRequest.getPrice();
+        final Long orderId = payRequest.getOrderId();
+        final String orderName = payRequest.getOrderName();
+        final Long price = payRequest.getPrice();
         final String encodedOrderId = orderIdTranslator.encode(orderId, orderName);
-        final Pay pay = new Pay(orderId, orderName, encodedOrderId, price);
-        return payRepository.save(pay)
-                .toPayResponse();
+        final Pay pay = Pay.builder()
+                           .orderId(orderId)
+                           .encodedOrderId(encodedOrderId)
+                           .orderName(orderName)
+                           .price(price)
+                           .build();
+        return PayResponse.of(payRepository.save(pay));
     }
 
     public void validatePay(final PaySuccessParameter paySuccessParameter) {

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -42,11 +42,10 @@ public class PayService {
         final String encodedOrderId = orderIdTranslator.encode(orderId, orderName);
         final Pay pay = Pay.builder()
                            .orderId(orderId)
-                           .encodedOrderId(encodedOrderId)
                            .orderName(orderName)
                            .price(price)
                            .build();
-        return PayResponse.from(payRepository.save(pay), successUrl, failUrl);
+        return PayResponse.from(payRepository.save(pay), encodedOrderId, successUrl, failUrl);
     }
 
     public void validatePay(final PayValidationRequest payValidationRequest) {

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -7,28 +7,21 @@ import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
 import com.gugucon.shopping.pay.infrastructure.PayValidator;
 import com.gugucon.shopping.pay.repository.PayRepository;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@AllArgsConstructor
 public class PayService {
 
     private final PayRepository payRepository;
     private final PayValidator payValidator;
     private final OrderIdTranslator orderIdTranslator;
 
-    public PayService(final PayRepository payRepository,
-                      final PayValidator payValidator,
-                      final OrderIdTranslator orderIdTranslator) {
-        this.payRepository = payRepository;
-        this.payValidator = payValidator;
-        this.orderIdTranslator = orderIdTranslator;
-    }
-
     @Transactional
     public PayResponse createPay(final PayRequest payRequest) {
-        // TODO: 결제 금액이 실제 주문 금액과 같은지 확인
         final Long orderId = payRequest.getOrderId();
         final String orderName = payRequest.getOrderName();
         final Long price = payRequest.getPrice();

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -6,7 +6,6 @@ import com.gugucon.shopping.pay.dto.PayResponse;
 import com.gugucon.shopping.pay.dto.PaySuccessParameter;
 import com.gugucon.shopping.pay.infrastructure.TossPayValidator;
 import com.gugucon.shopping.pay.repository.PayRepository;
-import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -7,18 +7,32 @@ import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
 import com.gugucon.shopping.pay.infrastructure.PayValidator;
 import com.gugucon.shopping.pay.repository.PayRepository;
-import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
-@AllArgsConstructor
 public class PayService {
 
     private final PayRepository payRepository;
     private final PayValidator payValidator;
     private final OrderIdTranslator orderIdTranslator;
+
+    private final String successUrl;
+    private final String failUrl;
+
+    public PayService(final PayRepository payRepository,
+                      final PayValidator payValidator,
+                      final OrderIdTranslator orderIdTranslator,
+                      @Value("${pay.callback.success-url}") final String successUrl,
+                      @Value("${pay.callback.fail-url}") final String failUrl) {
+        this.payRepository = payRepository;
+        this.payValidator = payValidator;
+        this.orderIdTranslator = orderIdTranslator;
+        this.successUrl = successUrl;
+        this.failUrl = failUrl;
+    }
 
     @Transactional
     public PayResponse createPay(final PayRequest payRequest) {
@@ -32,7 +46,7 @@ public class PayService {
                            .orderName(orderName)
                            .price(price)
                            .build();
-        return PayResponse.of(payRepository.save(pay));
+        return PayResponse.from(payRepository.save(pay), successUrl, failUrl);
     }
 
     public void validatePay(final PayValidationRequest payValidationRequest) {

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -16,21 +16,21 @@ public class PayService {
     private final PayRepository payRepository;
     private final TossPayValidator tossPayValidator;
 
-    public PayService(PayRepository payRepository, TossPayValidator tossPayValidator) {
+    public PayService(final PayRepository payRepository, final TossPayValidator tossPayValidator) {
         this.payRepository = payRepository;
         this.tossPayValidator = tossPayValidator;
     }
 
     @Transactional
-    public PayResponse createPay(PayRequest payRequest) {
+    public PayResponse createPay(final PayRequest payRequest) {
         // TODO: 결제 금액이 실제 주문 금액과 같은지 확인
         final Pay pay = new Pay(payRequest.getOrderId(), payRequest.getOrderName(), payRequest.getPrice());
         return payRepository.save(pay)
                 .toPayResponse();
     }
 
-    public void validatePay(PaySuccessParameter paySuccessParameter) {
-        Pay pay = payRepository.findByEncodedOrderId(paySuccessParameter.getOrderId())
+    public void validatePay(final PaySuccessParameter paySuccessParameter) {
+        final Pay pay = payRepository.findByEncodedOrderId(paySuccessParameter.getOrderId())
                                .orElseThrow(RuntimeException::new);
         pay.validateMoney(paySuccessParameter.getPrice());
         tossPayValidator.validatePayment(paySuccessParameter);

--- a/src/main/java/com/gugucon/shopping/pay/application/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/application/PayService.java
@@ -5,7 +5,7 @@ import com.gugucon.shopping.pay.dto.PayRequest;
 import com.gugucon.shopping.pay.dto.PayResponse;
 import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
-import com.gugucon.shopping.pay.infrastructure.TossPayValidator;
+import com.gugucon.shopping.pay.infrastructure.PayValidator;
 import com.gugucon.shopping.pay.repository.PayRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,14 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class PayService {
 
     private final PayRepository payRepository;
-    private final TossPayValidator tossPayValidator;
+    private final PayValidator payValidator;
     private final OrderIdTranslator orderIdTranslator;
 
     public PayService(final PayRepository payRepository,
-                      final TossPayValidator tossPayValidator,
+                      final PayValidator payValidator,
                       final OrderIdTranslator orderIdTranslator) {
         this.payRepository = payRepository;
-        this.tossPayValidator = tossPayValidator;
+        this.payValidator = payValidator;
         this.orderIdTranslator = orderIdTranslator;
     }
 
@@ -43,10 +43,10 @@ public class PayService {
     }
 
     public void validatePay(final PayValidationRequest payValidationRequest) {
-        Long orderId = orderIdTranslator.decode(payValidationRequest.getOrderId());
+        final Long orderId = orderIdTranslator.decode(payValidationRequest.getOrderId());
         final Pay pay = payRepository.findByOrderId(orderId)
-                               .orElseThrow(RuntimeException::new);
+                                     .orElseThrow(RuntimeException::new);
         pay.validateMoney(payValidationRequest.getAmount());
-        tossPayValidator.validatePayment(payValidationRequest);
+        payValidator.validatePayment(payValidationRequest);
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/config/PayConfiguration.java
+++ b/src/main/java/com/gugucon/shopping/pay/config/PayConfiguration.java
@@ -4,6 +4,7 @@ import com.gugucon.shopping.pay.infrastructure.OrderIdBase64Translator;
 import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
 import com.gugucon.shopping.pay.infrastructure.PayValidator;
 import com.gugucon.shopping.pay.infrastructure.TossPayValidator;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,7 +17,7 @@ public class PayConfiguration {
     }
 
     @Bean
-    public PayValidator payValidator() {
-        return new TossPayValidator();
+    public PayValidator payValidator(@Value("${pay.toss.secret-key}") final String secretKey) {
+        return new TossPayValidator(secretKey);
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/config/PayConfiguration.java
+++ b/src/main/java/com/gugucon/shopping/pay/config/PayConfiguration.java
@@ -2,6 +2,8 @@ package com.gugucon.shopping.pay.config;
 
 import com.gugucon.shopping.pay.infrastructure.OrderIdBase64Translator;
 import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
+import com.gugucon.shopping.pay.infrastructure.PayValidator;
+import com.gugucon.shopping.pay.infrastructure.TossPayValidator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,5 +13,10 @@ public class PayConfiguration {
     @Bean
     public OrderIdTranslator orderIdTranslator() {
         return new OrderIdBase64Translator();
+    }
+
+    @Bean
+    public PayValidator payValidator() {
+        return new TossPayValidator();
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/config/PayConfiguration.java
+++ b/src/main/java/com/gugucon/shopping/pay/config/PayConfiguration.java
@@ -1,0 +1,15 @@
+package com.gugucon.shopping.pay.config;
+
+import com.gugucon.shopping.pay.infrastructure.OrderIdBase64Translator;
+import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PayConfiguration {
+
+    @Bean
+    public OrderIdTranslator orderIdTranslator() {
+        return new OrderIdBase64Translator();
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -1,13 +1,12 @@
 package com.gugucon.shopping.pay.domain;
 
-import com.gugucon.shopping.pay.dto.PayResponse;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.Base64;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public final class Pay {
 
     @Id
@@ -28,14 +28,6 @@ public final class Pay {
     private String orderName;
 
     private Long price;
-
-    public Pay(final Long orderId, final String encodedOrderId, final String orderName, final Long price) {
-        this(null, orderId, encodedOrderId, orderName, price);
-    }
-
-    public PayResponse toPayResponse() {
-        return new PayResponse(encodedOrderId, orderName);
-    }
 
     public void validateMoney(final int price) {
         if (this.price != price) {

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -16,19 +16,25 @@ public final class Pay {
 
     private Long orderId;
 
+    private String encodedOrderId;
+
+    private String orderName;
+
     private Long price;
 
     public Pay() {
     }
 
-    private Pay(final Long id, final Long orderId, final Long price) {
+    private Pay(final Long id, final Long orderId, final String orderName, final Long price) {
         this.id = id;
         this.orderId = orderId;
+        this.orderName = orderName;
+        this.encodedOrderId = Base64.getEncoder().encodeToString((orderId + orderName).getBytes());
         this.price = price;
     }
 
-    public Pay(final Long orderId, final Long price) {
-        this(null, orderId, price);
+    public Pay(final Long orderId, final String orderName, final Long price) {
+        this(null, orderId, orderName, price);
     }
 
     public Long getId() {
@@ -44,9 +50,12 @@ public final class Pay {
     }
 
     public PayResponse toPayResponse() {
-        // TODO: 주문 이름 가져오기
-        final String orderName = "대충 주문 이름";
-        final String encodedOrderId = Base64.getEncoder().encodeToString((orderId + orderName).getBytes());
         return new PayResponse(encodedOrderId, orderName);
+    }
+
+    public void validateMoney(int price) {
+        if (this.price == price) {
+            throw new RuntimeException();
+        }
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -29,8 +29,8 @@ public final class Pay {
 
     private Long price;
 
-    public void validateMoney(final int price) {
-        if (this.price != price) {
+    public void validateMoney(final Long price) {
+        if (!this.price.equals(price)) {
             throw new RuntimeException();
         }
     }

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -38,7 +38,7 @@ public final class Pay {
     }
 
     public void validateMoney(int price) {
-        if (this.price == price) {
+        if (this.price != price) {
             throw new RuntimeException();
         }
     }

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -29,8 +29,8 @@ public final class Pay {
 
     private Long price;
 
-    public Pay(final Long orderId, final String orderName, final Long price) {
-        this(null, orderId, Base64.getEncoder().encodeToString((orderId + orderName).getBytes()), orderName, price);
+    public Pay(final Long orderId, final String encodedOrderId, final String orderName, final Long price) {
+        this(null, orderId, encodedOrderId, orderName, price);
     }
 
     public PayResponse toPayResponse() {

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -6,8 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.util.Base64;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Pay {
 
     @Id
@@ -22,31 +29,8 @@ public final class Pay {
 
     private Long price;
 
-    public Pay() {
-    }
-
-    private Pay(final Long id, final Long orderId, final String orderName, final Long price) {
-        this.id = id;
-        this.orderId = orderId;
-        this.orderName = orderName;
-        this.encodedOrderId = Base64.getEncoder().encodeToString((orderId + orderName).getBytes());
-        this.price = price;
-    }
-
     public Pay(final Long orderId, final String orderName, final Long price) {
-        this(null, orderId, orderName, price);
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public Long getOrderId() {
-        return orderId;
-    }
-
-    public Long getPrice() {
-        return price;
+        this(null, orderId, Base64.getEncoder().encodeToString((orderId + orderName).getBytes()), orderName, price);
     }
 
     public PayResponse toPayResponse() {

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -23,8 +23,6 @@ public final class Pay {
 
     private Long orderId;
 
-    private String encodedOrderId;
-
     private String orderName;
 
     private Long price;

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -1,0 +1,52 @@
+package com.gugucon.shopping.pay.domain;
+
+import com.gugucon.shopping.pay.dto.PayResponse;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.Base64;
+
+@Entity
+public final class Pay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long orderId;
+
+    private Long price;
+
+    public Pay() {
+    }
+
+    private Pay(final Long id, final Long orderId, final Long price) {
+        this.id = id;
+        this.orderId = orderId;
+        this.price = price;
+    }
+
+    public Pay(final Long orderId, final Long price) {
+        this(null, orderId, price);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public PayResponse toPayResponse() {
+        // TODO: 주문 이름 가져오기
+        final String orderName = "대충 주문 이름";
+        final String encodedOrderId = Base64.getEncoder().encodeToString((orderId + orderName).getBytes());
+        return new PayResponse(encodedOrderId, orderName);
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
+++ b/src/main/java/com/gugucon/shopping/pay/domain/Pay.java
@@ -37,7 +37,7 @@ public final class Pay {
         return new PayResponse(encodedOrderId, orderName);
     }
 
-    public void validateMoney(int price) {
+    public void validateMoney(final int price) {
         if (this.price != price) {
             throw new RuntimeException();
         }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
@@ -1,26 +1,13 @@
 package com.gugucon.shopping.pay.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public final class PayFailParameter {
 
     private final String errorCode;
     private final String message;
     private final String orderId;
-
-    public PayFailParameter(final String errorCode, final String message, final String orderId) {
-        this.errorCode = errorCode;
-        this.message = message;
-        this.orderId = orderId;
-    }
-
-    public String getErrorCode() {
-        return errorCode;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public String getOrderId() {
-        return orderId;
-    }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
@@ -6,7 +6,7 @@ public final class PayFailParameter {
     private final String message;
     private final String orderId;
 
-    public PayFailParameter(String errorCode, String message, String orderId) {
+    public PayFailParameter(final String errorCode, final String message, final String orderId) {
         this.errorCode = errorCode;
         this.message = message;
         this.orderId = orderId;

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public final class PayFailParameter {
 
-    private final String errorCode;
+    private final String code;
     private final String message;
     private final String orderId;
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayFailParameter.java
@@ -1,0 +1,26 @@
+package com.gugucon.shopping.pay.dto;
+
+public final class PayFailParameter {
+
+    private final String errorCode;
+    private final String message;
+    private final String orderId;
+
+    public PayFailParameter(String errorCode, String message, String orderId) {
+        this.errorCode = errorCode;
+        this.message = message;
+        this.orderId = orderId;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayRequest.java
@@ -1,26 +1,13 @@
 package com.gugucon.shopping.pay.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public final class PayRequest {
 
     private final Long orderId;
     private final Long price;
     private final String orderName;
-
-    public PayRequest(final Long orderId, final Long price, String orderName) {
-        this.orderId = orderId;
-        this.price = price;
-        this.orderName = orderName;
-    }
-
-    public Long getOrderId() {
-        return orderId;
-    }
-
-    public Long getPrice() {
-        return price;
-    }
-
-    public String getOrderName() {
-        return orderName;
-    }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayRequest.java
@@ -4,10 +4,12 @@ public final class PayRequest {
 
     private final Long orderId;
     private final Long price;
+    private final String orderName;
 
-    public PayRequest(final Long orderId, final Long price) {
+    public PayRequest(final Long orderId, final Long price, String orderName) {
         this.orderId = orderId;
         this.price = price;
+        this.orderName = orderName;
     }
 
     public Long getOrderId() {
@@ -16,5 +18,9 @@ public final class PayRequest {
 
     public Long getPrice() {
         return price;
+    }
+
+    public String getOrderName() {
+        return orderName;
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayRequest.java
@@ -1,0 +1,20 @@
+package com.gugucon.shopping.pay.dto;
+
+public final class PayRequest {
+
+    private final Long orderId;
+    private final Long price;
+
+    public PayRequest(final Long orderId, final Long price) {
+        this.orderId = orderId;
+        this.price = price;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -1,5 +1,6 @@
 package com.gugucon.shopping.pay.dto;
 
+import com.gugucon.shopping.pay.domain.Pay;
 import lombok.Getter;
 
 @Getter
@@ -13,8 +14,12 @@ public final class PayResponse {
     private final String customerEmail = "asdf@asdf.asdf";
     private final String customerName = "김동주";
 
-    public PayResponse(final String encodedOrderId, final String orderName) {
+    private PayResponse(final String encodedOrderId, final String orderName) {
         this.encodedOrderId = encodedOrderId;
         this.orderName = orderName;
+    }
+
+    public static PayResponse of(final Pay pay) {
+        return new PayResponse(pay.getEncodedOrderId(), pay.getOrderName());
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -1,5 +1,8 @@
 package com.gugucon.shopping.pay.dto;
 
+import lombok.Getter;
+
+@Getter
 public final class PayResponse {
 
     private final String encodedOrderId;
@@ -13,29 +16,5 @@ public final class PayResponse {
     public PayResponse(final String encodedOrderId, final String orderName) {
         this.encodedOrderId = encodedOrderId;
         this.orderName = orderName;
-    }
-
-    public String getEncodedOrderId() {
-        return encodedOrderId;
-    }
-
-    public String getOrderName() {
-        return orderName;
-    }
-
-    public String getSuccessUrl() {
-        return successUrl;
-    }
-
-    public String getFailUrl() {
-        return failUrl;
-    }
-
-    public String getCustomerEmail() {
-        return customerEmail;
-    }
-
-    public String getCustomerName() {
-        return customerName;
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -8,7 +8,7 @@ public final class PayResponse {
 
     private final String encodedOrderId;
     private final String orderName;
-    private final String successUrl = "http://localhost:8080/pay/success";
+    private final String successUrl = "http://localhost:8080/pay/loading";
     private final String failUrl = "http://localhost:8080/pay/fail";
     // TODO: 회원 정보 가져오기?
     private final String customerEmail = "asdf@asdf.asdf";

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -11,12 +11,15 @@ public final class PayResponse {
     private static final String customerEmail = "asdf@asdf.asdf";
     private static final String customerName = "김동주";
 
-    private final String encodedOrderId;
     private final String orderName;
+    private final String encodedOrderId;
     private final String successUrl;
     private final String failUrl;
 
-    public static PayResponse from(final Pay pay, final String successUrl, final String failUrl) {
-        return new PayResponse(pay.getEncodedOrderId(), pay.getOrderName(), successUrl, failUrl);
+    public static PayResponse from(final Pay pay,
+                                   final String encodedOrderId,
+                                   final String successUrl,
+                                   final String failUrl) {
+        return new PayResponse(pay.getOrderName(), encodedOrderId, successUrl, failUrl);
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -1,0 +1,40 @@
+package com.gugucon.shopping.pay.dto;
+
+public final class PayResponse {
+
+    private final String encodedOrderId;
+    private final String orderName;
+    private final String successUrl = "http://localhost:8080/pay/success";
+    private final String failUrl = "http://localhost:8080/pay/fail";
+    private final String customerEmail = "asdf@asdf.asdf";
+    private final String customerName = "김동주";
+
+    public PayResponse(final String encodedOrderId, final String orderName) {
+        this.encodedOrderId = encodedOrderId;
+        this.orderName = orderName;
+    }
+
+    public String getEncodedOrderId() {
+        return encodedOrderId;
+    }
+
+    public String getOrderName() {
+        return orderName;
+    }
+
+    public String getSuccessUrl() {
+        return successUrl;
+    }
+
+    public String getFailUrl() {
+        return failUrl;
+    }
+
+    public String getCustomerEmail() {
+        return customerEmail;
+    }
+
+    public String getCustomerName() {
+        return customerName;
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -6,6 +6,7 @@ public final class PayResponse {
     private final String orderName;
     private final String successUrl = "http://localhost:8080/pay/success";
     private final String failUrl = "http://localhost:8080/pay/fail";
+    // TODO: 회원 정보 가져오기?
     private final String customerEmail = "asdf@asdf.asdf";
     private final String customerName = "김동주";
 

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -1,23 +1,20 @@
 package com.gugucon.shopping.pay.dto;
 
 import com.gugucon.shopping.pay.domain.Pay;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PayResponse {
 
     private final String encodedOrderId;
     private final String orderName;
-    private final String successUrl = "http://localhost:8080/pay/loading";
-    private final String failUrl = "http://localhost:8080/pay/fail";
-    // TODO: 회원 정보 가져오기?
-    private final String customerEmail = "asdf@asdf.asdf";
-    private final String customerName = "김동주";
-
-    private PayResponse(final String encodedOrderId, final String orderName) {
-        this.encodedOrderId = encodedOrderId;
-        this.orderName = orderName;
-    }
+    private static final String successUrl = "http://localhost:8080/pay/loading";
+    private static final String failUrl = "http://localhost:8080/pay/fail";
+    private static final String customerEmail = "asdf@asdf.asdf";
+    private static final String customerName = "김동주";
 
     public static PayResponse of(final Pay pay) {
         return new PayResponse(pay.getEncodedOrderId(), pay.getOrderName());

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayResponse.java
@@ -1,22 +1,22 @@
 package com.gugucon.shopping.pay.dto;
 
 import com.gugucon.shopping.pay.domain.Pay;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public final class PayResponse {
 
-    private final String encodedOrderId;
-    private final String orderName;
-    private static final String successUrl = "http://localhost:8080/pay/loading";
-    private static final String failUrl = "http://localhost:8080/pay/fail";
     private static final String customerEmail = "asdf@asdf.asdf";
     private static final String customerName = "김동주";
 
-    public static PayResponse of(final Pay pay) {
-        return new PayResponse(pay.getEncodedOrderId(), pay.getOrderName());
+    private final String encodedOrderId;
+    private final String orderName;
+    private final String successUrl;
+    private final String failUrl;
+
+    public static PayResponse from(final Pay pay, final String successUrl, final String failUrl) {
+        return new PayResponse(pay.getEncodedOrderId(), pay.getOrderName(), successUrl, failUrl);
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
@@ -7,7 +7,10 @@ public final class PaySuccessParameter {
     private final int price;
     private final String paymentType;
 
-    public PaySuccessParameter(String paymentKey, String orderId, int price, String paymentType) {
+    public PaySuccessParameter(final String paymentKey,
+                               final String orderId,
+                               final int price,
+                               final String paymentType) {
         this.paymentKey = paymentKey;
         this.orderId = orderId;
         this.price = price;

--- a/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
@@ -1,0 +1,32 @@
+package com.gugucon.shopping.pay.dto;
+
+public final class PaySuccessParameter {
+
+    private final String paymentKey;
+    private final String orderId;
+    private final int price;
+    private final String paymentType;
+
+    public PaySuccessParameter(String paymentKey, String orderId, int price, String paymentType) {
+        this.paymentKey = paymentKey;
+        this.orderId = orderId;
+        this.price = price;
+        this.paymentType = paymentType;
+    }
+
+    public String getPaymentKey() {
+        return paymentKey;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public String getPaymentType() {
+        return paymentType;
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
@@ -9,6 +9,6 @@ public final class PaySuccessParameter {
 
     private final String paymentKey;
     private final String orderId;
-    private final int price;
+    private final Long price;
     private final String paymentType;
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
@@ -1,35 +1,14 @@
 package com.gugucon.shopping.pay.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public final class PaySuccessParameter {
 
     private final String paymentKey;
     private final String orderId;
     private final int price;
     private final String paymentType;
-
-    public PaySuccessParameter(final String paymentKey,
-                               final String orderId,
-                               final int price,
-                               final String paymentType) {
-        this.paymentKey = paymentKey;
-        this.orderId = orderId;
-        this.price = price;
-        this.paymentType = paymentType;
-    }
-
-    public String getPaymentKey() {
-        return paymentKey;
-    }
-
-    public String getOrderId() {
-        return orderId;
-    }
-
-    public int getPrice() {
-        return price;
-    }
-
-    public String getPaymentType() {
-        return paymentType;
-    }
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PaySuccessParameter.java
@@ -9,6 +9,6 @@ public final class PaySuccessParameter {
 
     private final String paymentKey;
     private final String orderId;
-    private final Long price;
+    private final Long amount;
     private final String paymentType;
 }

--- a/src/main/java/com/gugucon/shopping/pay/dto/PayValidationRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/dto/PayValidationRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public final class PaySuccessParameter {
+public final class PayValidationRequest {
 
     private final String paymentKey;
     private final String orderId;

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64Translator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64Translator.java
@@ -1,0 +1,31 @@
+package com.gugucon.shopping.pay.infrastructure;
+
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Base64.Decoder;
+import java.util.Base64.Encoder;
+
+public final class OrderIdBase64Translator implements OrderIdTranslator {
+
+    private static final String DELIMITER = "--";
+
+    private final Encoder encoder;
+    private final Decoder decoder;
+
+    public OrderIdBase64Translator() {
+        this.encoder = Base64.getEncoder();
+        this.decoder = Base64.getDecoder();
+    }
+
+    @Override
+    public String encode(final Long orderId, final String orderName) {
+        final String joinned = String.join(DELIMITER, orderId.toString(), orderName, LocalDateTime.now().toString());
+        return encoder.encodeToString(joinned.getBytes());
+    }
+
+    @Override
+    public Long decode(final String encodedOrderId) {
+        String decoded = new String(decoder.decode(encodedOrderId.getBytes()));
+        return Long.parseLong(decoded.split(DELIMITER)[0]);
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64Translator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64Translator.java
@@ -19,13 +19,20 @@ public final class OrderIdBase64Translator implements OrderIdTranslator {
 
     @Override
     public String encode(final Long orderId, final String orderName) {
-        final String joinned = String.join(DELIMITER, orderId.toString(), orderName, LocalDateTime.now().toString());
-        return encoder.encodeToString(joinned.getBytes());
+        final String joined = String.join(DELIMITER,
+                                           String.valueOf(orderId),
+                                           orderName,
+                                           String.valueOf(LocalDateTime.now()));
+        return encoder.encodeToString(joined.getBytes());
     }
 
     @Override
     public Long decode(final String encodedOrderId) {
         String decoded = new String(decoder.decode(encodedOrderId.getBytes()));
-        return Long.parseLong(decoded.split(DELIMITER)[0]);
+        try{
+            return Long.parseLong(decoded.split(DELIMITER)[0]);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException();
+        }
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdTranslator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdTranslator.java
@@ -1,0 +1,7 @@
+package com.gugucon.shopping.pay.infrastructure;
+
+public interface OrderIdTranslator {
+
+    public String encode(Long orderId, String orderName);
+    public Long decode(String encodedOrderId);
+}

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdTranslator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdTranslator.java
@@ -2,6 +2,6 @@ package com.gugucon.shopping.pay.infrastructure;
 
 public interface OrderIdTranslator {
 
-    public String encode(Long orderId, String orderName);
-    public Long decode(String encodedOrderId);
+    String encode(final Long orderId, final String orderName);
+    Long decode(final String encodedOrderId);
 }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/PayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/PayValidator.java
@@ -1,0 +1,8 @@
+package com.gugucon.shopping.pay.infrastructure;
+
+import com.gugucon.shopping.pay.dto.PayValidationRequest;
+
+public interface PayValidator {
+
+    void validatePayment(final PayValidationRequest payValidationRequest);
+}

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -1,6 +1,6 @@
 package com.gugucon.shopping.pay.infrastructure;
 
-import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.dto.TossValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.dto.TossValidationResponse;
 import java.util.Base64;
@@ -30,9 +30,9 @@ public final class TossPayValidator {
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
     }
 
-    public void validatePayment(final PaySuccessParameter paySuccessParameter) {
+    public void validatePayment(final PayValidationRequest payValidationRequest) {
         httpHeaders.setBasicAuth(Base64.getEncoder().encodeToString((secretKey + ":").getBytes()));
-        final TossValidationRequest tossValidationRequest = TossValidationRequest.of(paySuccessParameter);
+        final TossValidationRequest tossValidationRequest = TossValidationRequest.of(payValidationRequest);
         final HttpEntity<TossValidationRequest> request = new HttpEntity<>(tossValidationRequest, httpHeaders);
         final ResponseEntity<TossValidationResponse> response = restTemplate.postForEntity(VALIDATE_URL,
                                                                                      request,

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -19,22 +19,19 @@ public final class TossPayValidator implements PayValidator {
     private static final String BASIC_AUTH_DELIMITER = ":";
 
     private final RestTemplate restTemplate;
-    private final HttpHeaders httpHeaders;
     private final Encoder encoder;
+    private final HttpHeaders httpHeaders;
 
-    @Value("${pay.toss.secret-key}")
-    private String secretKey;
-
-    public TossPayValidator() {
+    public TossPayValidator(final String secretKey) {
         this.restTemplate = new RestTemplate();
+        this.encoder = Base64.getEncoder();
         this.httpHeaders = new HttpHeaders();
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-        this.encoder = Base64.getEncoder();
+        httpHeaders.setBasicAuth(encoder.encodeToString((secretKey + BASIC_AUTH_DELIMITER).getBytes()));
     }
 
     @Override
     public void validatePayment(final PayValidationRequest payValidationRequest) {
-        httpHeaders.setBasicAuth(encoder.encodeToString((secretKey + BASIC_AUTH_DELIMITER).getBytes()));
         final TossValidationRequest tossValidationRequest = TossValidationRequest.of(payValidationRequest);
         final HttpEntity<TossValidationRequest> request = new HttpEntity<>(tossValidationRequest, httpHeaders);
         final ResponseEntity<TossValidationResponse> response = restTemplate.postForEntity(VALIDATE_URL,

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -5,7 +5,6 @@ import com.gugucon.shopping.pay.infrastructure.dto.TossValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.dto.TossValidationResponse;
 import java.util.Base64;
 import java.util.Base64.Encoder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -19,14 +18,17 @@ public final class TossPayValidator implements PayValidator {
     private static final String BASIC_AUTH_DELIMITER = ":";
 
     private final RestTemplate restTemplate;
-    private final Encoder encoder;
     private final HttpHeaders httpHeaders;
 
     public TossPayValidator(final String secretKey) {
         this.restTemplate = new RestTemplate();
-        this.encoder = Base64.getEncoder();
         this.httpHeaders = new HttpHeaders();
+        setHeaderForConnect(secretKey);
+    }
+
+    private void setHeaderForConnect(final String secretKey) {
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        Encoder encoder = Base64.getEncoder();
         httpHeaders.setBasicAuth(encoder.encodeToString((secretKey + BASIC_AUTH_DELIMITER).getBytes()));
     }
 

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -4,22 +4,23 @@ import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.dto.TossValidationRequest;
 import com.gugucon.shopping.pay.infrastructure.dto.TossValidationResponse;
 import java.util.Base64;
+import java.util.Base64.Encoder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-@Component
-public final class TossPayValidator {
+public final class TossPayValidator implements PayValidator {
 
     private static final String VALIDATE_URL = "https://api.tosspayments.com/v1/payments/confirm";
+    private static final String BASIC_AUTH_DELIMITER = ":";
 
     private final RestTemplate restTemplate;
     private final HttpHeaders httpHeaders;
+    private final Encoder encoder;
 
     @Value("${toss.pay.secret-key}")
     private String secretKey;
@@ -28,15 +29,17 @@ public final class TossPayValidator {
         this.restTemplate = new RestTemplate();
         this.httpHeaders = new HttpHeaders();
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        this.encoder = Base64.getEncoder();
     }
 
+    @Override
     public void validatePayment(final PayValidationRequest payValidationRequest) {
-        httpHeaders.setBasicAuth(Base64.getEncoder().encodeToString((secretKey + ":").getBytes()));
+        httpHeaders.setBasicAuth(encoder.encodeToString((secretKey + BASIC_AUTH_DELIMITER).getBytes()));
         final TossValidationRequest tossValidationRequest = TossValidationRequest.of(payValidationRequest);
         final HttpEntity<TossValidationRequest> request = new HttpEntity<>(tossValidationRequest, httpHeaders);
         final ResponseEntity<TossValidationResponse> response = restTemplate.postForEntity(VALIDATE_URL,
-                                                                                     request,
-                                                                                     TossValidationResponse.class);
+                                                                                           request,
+                                                                                           TossValidationResponse.class);
         validateSuccess(response);
     }
 

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -22,7 +22,7 @@ public final class TossPayValidator implements PayValidator {
     private final HttpHeaders httpHeaders;
     private final Encoder encoder;
 
-    @Value("${toss.pay.secret-key}")
+    @Value("${pay.toss.secret-key}")
     private String secretKey;
 
     public TossPayValidator() {

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -1,0 +1,55 @@
+package com.gugucon.shopping.pay.infrastructure;
+
+import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+import com.gugucon.shopping.pay.infrastructure.dto.TossValidationRequest;
+import com.gugucon.shopping.pay.infrastructure.dto.TossValidationResponse;
+import java.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class TossPayValidator {
+
+    private static final String VALIDATE_URL = "https://api.tosspayments.com/v1/payments/confirm";
+
+    private final RestTemplate restTemplate;
+    private final HttpHeaders httpHeaders;
+
+    @Value("${toss.pay.secret-key}")
+    private String secretKey;
+
+    public TossPayValidator() {
+        this.restTemplate = new RestTemplate();
+        this.httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+    }
+
+    public void validatePayment(PaySuccessParameter paySuccessParameter) {
+        httpHeaders.setBasicAuth(Base64.getEncoder().encodeToString((secretKey + ":").getBytes()));
+        TossValidationRequest tossValidationRequest = TossValidationRequest.of(paySuccessParameter);
+        HttpEntity<TossValidationRequest> request = new HttpEntity<>(tossValidationRequest, httpHeaders);
+        ResponseEntity<TossValidationResponse> response = restTemplate.postForEntity(VALIDATE_URL,
+                                                                                     request,
+                                                                                     TossValidationResponse.class);
+        validateSuccess(response);
+    }
+
+    private void validateSuccess(ResponseEntity<TossValidationResponse> response) {
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new RuntimeException();
+        }
+        if (response.getBody() == null) {
+            throw new RuntimeException();
+        }
+        if (!response.getBody().getStatus().equals("DONE")) {
+            throw new RuntimeException();
+        }
+        System.out.println(response.getBody());
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -50,6 +50,5 @@ public class TossPayValidator {
         if (!response.getBody().getStatus().equals("DONE")) {
             throw new RuntimeException();
         }
-        System.out.println(response.getBody());
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/TossPayValidator.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 @Component
-public class TossPayValidator {
+public final class TossPayValidator {
 
     private static final String VALIDATE_URL = "https://api.tosspayments.com/v1/payments/confirm";
 
@@ -30,17 +30,17 @@ public class TossPayValidator {
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
     }
 
-    public void validatePayment(PaySuccessParameter paySuccessParameter) {
+    public void validatePayment(final PaySuccessParameter paySuccessParameter) {
         httpHeaders.setBasicAuth(Base64.getEncoder().encodeToString((secretKey + ":").getBytes()));
-        TossValidationRequest tossValidationRequest = TossValidationRequest.of(paySuccessParameter);
-        HttpEntity<TossValidationRequest> request = new HttpEntity<>(tossValidationRequest, httpHeaders);
-        ResponseEntity<TossValidationResponse> response = restTemplate.postForEntity(VALIDATE_URL,
+        final TossValidationRequest tossValidationRequest = TossValidationRequest.of(paySuccessParameter);
+        final HttpEntity<TossValidationRequest> request = new HttpEntity<>(tossValidationRequest, httpHeaders);
+        final ResponseEntity<TossValidationResponse> response = restTemplate.postForEntity(VALIDATE_URL,
                                                                                      request,
                                                                                      TossValidationResponse.class);
         validateSuccess(response);
     }
 
-    private void validateSuccess(ResponseEntity<TossValidationResponse> response) {
+    private void validateSuccess(final ResponseEntity<TossValidationResponse> response) {
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new RuntimeException();
         }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
@@ -1,6 +1,6 @@
 package com.gugucon.shopping.pay.infrastructure.dto;
 
-import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,9 +12,9 @@ public final class TossValidationRequest {
     private final String orderId;
     private final Long amount;
 
-    public static TossValidationRequest of(final PaySuccessParameter paySuccessParameter) {
-        return new TossValidationRequest(paySuccessParameter.getPaymentKey(),
-                                         paySuccessParameter.getOrderId(),
-                                         paySuccessParameter.getAmount());
+    public static TossValidationRequest of(final PayValidationRequest payValidationRequest) {
+        return new TossValidationRequest(payValidationRequest.getPaymentKey(),
+                                         payValidationRequest.getOrderId(),
+                                         payValidationRequest.getAmount());
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
@@ -15,6 +15,6 @@ public final class TossValidationRequest {
     public static TossValidationRequest of(final PaySuccessParameter paySuccessParameter) {
         return new TossValidationRequest(paySuccessParameter.getPaymentKey(),
                                          paySuccessParameter.getOrderId(),
-                                         paySuccessParameter.getPrice());
+                                         paySuccessParameter.getAmount());
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
@@ -1,0 +1,34 @@
+package com.gugucon.shopping.pay.infrastructure.dto;
+
+import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+
+public final class TossValidationRequest {
+
+    private final String paymentKey;
+    private final String orderId;
+    private final int amount;
+
+    public TossValidationRequest(final String paymentKey, final String orderId, final int amount) {
+        this.paymentKey = paymentKey;
+        this.orderId = orderId;
+        this.amount = amount;
+    }
+
+    public static TossValidationRequest of(PaySuccessParameter paySuccessParameter) {
+        return new TossValidationRequest(paySuccessParameter.getPaymentKey(),
+                                         paySuccessParameter.getOrderId(),
+                                         paySuccessParameter.getPrice());
+    }
+
+    public String getPaymentKey() {
+        return paymentKey;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
@@ -10,9 +10,9 @@ public final class TossValidationRequest {
 
     private final String paymentKey;
     private final String orderId;
-    private final int amount;
+    private final Long amount;
 
-    public static TossValidationRequest of(PaySuccessParameter paySuccessParameter) {
+    public static TossValidationRequest of(final PaySuccessParameter paySuccessParameter) {
         return new TossValidationRequest(paySuccessParameter.getPaymentKey(),
                                          paySuccessParameter.getOrderId(),
                                          paySuccessParameter.getPrice());

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationRequest.java
@@ -1,34 +1,20 @@
 package com.gugucon.shopping.pay.infrastructure.dto;
 
 import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 public final class TossValidationRequest {
 
     private final String paymentKey;
     private final String orderId;
     private final int amount;
 
-    public TossValidationRequest(final String paymentKey, final String orderId, final int amount) {
-        this.paymentKey = paymentKey;
-        this.orderId = orderId;
-        this.amount = amount;
-    }
-
     public static TossValidationRequest of(PaySuccessParameter paySuccessParameter) {
         return new TossValidationRequest(paySuccessParameter.getPaymentKey(),
                                          paySuccessParameter.getOrderId(),
                                          paySuccessParameter.getPrice());
-    }
-
-    public String getPaymentKey() {
-        return paymentKey;
-    }
-
-    public String getOrderId() {
-        return orderId;
-    }
-
-    public int getAmount() {
-        return amount;
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
@@ -1,11 +1,12 @@
 package com.gugucon.shopping.pay.infrastructure.dto;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public final class TossValidationResponse {
 

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
@@ -1,0 +1,46 @@
+package com.gugucon.shopping.pay.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public final class TossValidationResponse {
+
+    private final String paymentKey;
+    private final String status;
+    private final String orderId;
+    private final String orderName;
+    private final String method;
+
+    @JsonCreator
+    public TossValidationResponse(@JsonProperty("paymentKey") final String paymentKey,
+                                  @JsonProperty("status") final String status,
+                                  @JsonProperty("orderId") final String orderId,
+                                  @JsonProperty("orderName") final String orderName,
+                                  @JsonProperty("method") final String method) {
+        this.paymentKey = paymentKey;
+        this.status = status;
+        this.orderId = orderId;
+        this.orderName = orderName;
+        this.method = method;
+    }
+
+    public String getPaymentKey() {
+        return paymentKey;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public String getOrderName() {
+        return orderName;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
@@ -2,7 +2,9 @@ package com.gugucon.shopping.pay.infrastructure.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
+@Getter
 public final class TossValidationResponse {
 
     private final String paymentKey;
@@ -22,25 +24,5 @@ public final class TossValidationResponse {
         this.orderId = orderId;
         this.orderName = orderName;
         this.method = method;
-    }
-
-    public String getPaymentKey() {
-        return paymentKey;
-    }
-
-    public String getStatus() {
-        return status;
-    }
-
-    public String getOrderId() {
-        return orderId;
-    }
-
-    public String getOrderName() {
-        return orderName;
-    }
-
-    public String getMethod() {
-        return method;
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/dto/TossValidationResponse.java
@@ -1,28 +1,17 @@
 package com.gugucon.shopping.pay.infrastructure.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public final class TossValidationResponse {
 
-    private final String paymentKey;
-    private final String status;
-    private final String orderId;
-    private final String orderName;
-    private final String method;
-
-    @JsonCreator
-    public TossValidationResponse(@JsonProperty("paymentKey") final String paymentKey,
-                                  @JsonProperty("status") final String status,
-                                  @JsonProperty("orderId") final String orderId,
-                                  @JsonProperty("orderName") final String orderName,
-                                  @JsonProperty("method") final String method) {
-        this.paymentKey = paymentKey;
-        this.status = status;
-        this.orderId = orderId;
-        this.orderName = orderName;
-        this.method = method;
-    }
+    private String paymentKey;
+    private String status;
+    private String orderId;
+    private String orderName;
+    private String method;
 }

--- a/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
+++ b/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PayRepository extends JpaRepository<Pay, Long> {
 
-    Optional<Pay> findByEncodedOrderId(String encodedOrderId);
+    Optional<Pay> findByEncodedOrderId(final String encodedOrderId);
 }

--- a/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
+++ b/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PayRepository extends JpaRepository<Pay, Long> {
 
-    Optional<Pay> findByEncodedOrderId(final String encodedOrderId);
+    Optional<Pay> findByOrderId(final Long orderId);
 }

--- a/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
+++ b/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
@@ -1,9 +1,12 @@
 package com.gugucon.shopping.pay.repository;
 
 import com.gugucon.shopping.pay.domain.Pay;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PayRepository extends JpaRepository<Pay, Long> {
+
+    Optional<Pay> findByEncodedOrderId(String encodedOrderId);
 }

--- a/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
+++ b/src/main/java/com/gugucon/shopping/pay/repository/PayRepository.java
@@ -1,0 +1,9 @@
+package com.gugucon.shopping.pay.repository;
+
+import com.gugucon.shopping.pay.domain.Pay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PayRepository extends JpaRepository<Pay, Long> {
+}

--- a/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
+++ b/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
@@ -17,7 +17,7 @@ public final class PayController {
 
     private final PayService payService;
 
-    public PayController(PayService payService) {
+    public PayController(final PayService payService) {
         this.payService = payService;
     }
 
@@ -27,26 +27,29 @@ public final class PayController {
     }
 
     @PostMapping("/api/pay")
-    public ResponseEntity<PayResponse> createPayment(@RequestBody PayRequest payRequest) {
-        PayResponse payResponse = payService.createPay(payRequest);
+    public ResponseEntity<PayResponse> createPayment(@RequestBody final PayRequest payRequest) {
+        final PayResponse payResponse = payService.createPay(payRequest);
         return ResponseEntity.ok(payResponse);
     }
 
     @GetMapping("/pay/success")
-    public String getSuccessPage(@RequestParam("paymentKey") String paymentKey,
-                                 @RequestParam("orderId") String orderId,
-                                 @RequestParam("amount") int price,
-                                 @RequestParam("paymentType") String paymentType) {
-        PaySuccessParameter paySuccessParameter = new PaySuccessParameter(paymentKey, orderId, price, paymentType);
+    public String getSuccessPage(@RequestParam("paymentKey") final String paymentKey,
+                                 @RequestParam("orderId") final String orderId,
+                                 @RequestParam("amount") final int price,
+                                 @RequestParam("paymentType") final String paymentType) {
+        final PaySuccessParameter paySuccessParameter = new PaySuccessParameter(paymentKey,
+                                                                                orderId,
+                                                                                price,
+                                                                                paymentType);
         payService.validatePay(paySuccessParameter);
         return "pay-success";
     }
 
     @GetMapping("/pay/fail")
-    public String getFailPage(@RequestParam("code") String errorCode,
-                              @RequestParam("message") String message,
-                              @RequestParam("orderId") String orderId) {
-        PayFailParameter payFailParameter = new PayFailParameter(errorCode, message, orderId);
+    public String getFailPage(@RequestParam("code") final String errorCode,
+                              @RequestParam("message") final String message,
+                              @RequestParam("orderId") final String orderId) {
+        final PayFailParameter payFailParameter = new PayFailParameter(errorCode, message, orderId);
         return "pay-fail";
     }
 

--- a/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
+++ b/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
@@ -1,13 +1,16 @@
 package com.gugucon.shopping.pay.ui;
 
 import com.gugucon.shopping.pay.application.PayService;
+import com.gugucon.shopping.pay.dto.PayFailParameter;
 import com.gugucon.shopping.pay.dto.PayRequest;
 import com.gugucon.shopping.pay.dto.PayResponse;
+import com.gugucon.shopping.pay.dto.PaySuccessParameter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public final class PayController {
@@ -24,8 +27,27 @@ public final class PayController {
     }
 
     @PostMapping("/api/pay")
-    public ResponseEntity<PayResponse> validatePayment(@RequestBody PayRequest payRequest) {
+    public ResponseEntity<PayResponse> createPayment(@RequestBody PayRequest payRequest) {
         PayResponse payResponse = payService.createPay(payRequest);
         return ResponseEntity.ok(payResponse);
     }
+
+    @GetMapping("/pay/success")
+    public String getSuccessPage(@RequestParam("paymentKey") String paymentKey,
+                                 @RequestParam("orderId") String orderId,
+                                 @RequestParam("amount") int price,
+                                 @RequestParam("paymentType") String paymentType) {
+        PaySuccessParameter paySuccessParameter = new PaySuccessParameter(paymentKey, orderId, price, paymentType);
+        payService.validatePay(paySuccessParameter);
+        return "pay-success";
+    }
+
+    @GetMapping("/pay/fail")
+    public String getFailPage(@RequestParam("code") String errorCode,
+                              @RequestParam("messgae") String message,
+                              @RequestParam("orderId") String orderId) {
+        PayFailParameter payFailParameter = new PayFailParameter(errorCode, message, orderId);
+        return "pay-fail";
+    }
+
 }

--- a/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
+++ b/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
@@ -4,14 +4,13 @@ import com.gugucon.shopping.pay.application.PayService;
 import com.gugucon.shopping.pay.dto.PayFailParameter;
 import com.gugucon.shopping.pay.dto.PayRequest;
 import com.gugucon.shopping.pay.dto.PayResponse;
-import com.gugucon.shopping.pay.dto.PaySuccessParameter;
+import com.gugucon.shopping.pay.dto.PayValidationRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public final class PayController {
@@ -33,10 +32,20 @@ public final class PayController {
         return ResponseEntity.ok(payResponse);
     }
 
+    @PostMapping("/api/pay/validate")
+    public ResponseEntity<Void> validatePayment(@RequestBody final PayValidationRequest payValidationRequest) {
+        payService.validatePay(payValidationRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/pay/success")
-    public String getSuccessPage(@ModelAttribute final PaySuccessParameter paySuccessParameter) {
-        payService.validatePay(paySuccessParameter);
+    public String getSuccessPage() {
         return "pay-success";
+    }
+
+    @GetMapping("/pay/loading")
+    public String getLoadingPage(@ModelAttribute final PayValidationRequest payValidationRequest) {
+        return "pay-loading";
     }
 
     @GetMapping("/pay/fail")

--- a/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
+++ b/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
@@ -8,6 +8,7 @@ import com.gugucon.shopping.pay.dto.PaySuccessParameter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,23 +34,13 @@ public final class PayController {
     }
 
     @GetMapping("/pay/success")
-    public String getSuccessPage(@RequestParam("paymentKey") final String paymentKey,
-                                 @RequestParam("orderId") final String orderId,
-                                 @RequestParam("amount") final Long price,
-                                 @RequestParam("paymentType") final String paymentType) {
-        final PaySuccessParameter paySuccessParameter = new PaySuccessParameter(paymentKey,
-                                                                                orderId,
-                                                                                price,
-                                                                                paymentType);
+    public String getSuccessPage(@ModelAttribute final PaySuccessParameter paySuccessParameter) {
         payService.validatePay(paySuccessParameter);
         return "pay-success";
     }
 
     @GetMapping("/pay/fail")
-    public String getFailPage(@RequestParam("code") final String errorCode,
-                              @RequestParam("message") final String message,
-                              @RequestParam("orderId") final String orderId) {
-        final PayFailParameter payFailParameter = new PayFailParameter(errorCode, message, orderId);
+    public String getFailPage(@ModelAttribute final PayFailParameter payFailParameter) {
         return "pay-fail";
     }
 

--- a/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
+++ b/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
@@ -1,0 +1,31 @@
+package com.gugucon.shopping.pay.ui;
+
+import com.gugucon.shopping.pay.application.PayService;
+import com.gugucon.shopping.pay.dto.PayRequest;
+import com.gugucon.shopping.pay.dto.PayResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+public final class PayController {
+
+    private final PayService payService;
+
+    public PayController(PayService payService) {
+        this.payService = payService;
+    }
+
+    @GetMapping("/pay")
+    public String getPayPage() {
+        return "pay";
+    }
+
+    @PostMapping("/api/pay")
+    public ResponseEntity<PayResponse> validatePayment(@RequestBody PayRequest payRequest) {
+        PayResponse payResponse = payService.createPay(payRequest);
+        return ResponseEntity.ok(payResponse);
+    }
+}

--- a/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
+++ b/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
@@ -44,7 +44,7 @@ public final class PayController {
 
     @GetMapping("/pay/fail")
     public String getFailPage(@RequestParam("code") String errorCode,
-                              @RequestParam("messgae") String message,
+                              @RequestParam("message") String message,
                               @RequestParam("orderId") String orderId) {
         PayFailParameter payFailParameter = new PayFailParameter(errorCode, message, orderId);
         return "pay-fail";

--- a/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
+++ b/src/main/java/com/gugucon/shopping/pay/ui/PayController.java
@@ -35,7 +35,7 @@ public final class PayController {
     @GetMapping("/pay/success")
     public String getSuccessPage(@RequestParam("paymentKey") final String paymentKey,
                                  @RequestParam("orderId") final String orderId,
-                                 @RequestParam("amount") final int price,
+                                 @RequestParam("amount") final Long price,
                                  @RequestParam("paymentType") final String paymentType) {
         final PaySuccessParameter paySuccessParameter = new PaySuccessParameter(paymentKey,
                                                                                 orderId,

--- a/src/main/resources/templates/pay-fail.html
+++ b/src/main/resources/templates/pay-fail.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>결제 실패</title>
+</head>
+<body>
+  <span>결제에 실패하였습니다.</span>
+</body>
+</html>

--- a/src/main/resources/templates/pay-loading.html
+++ b/src/main/resources/templates/pay-loading.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>결제 승인 대기 중</title>
+</head>
+<body>
+  <span>결제 승인 대기 중 입니다.</span>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const urlParams = new URLSearchParams(window.location.search);
+      const paymentKey = urlParams.get('paymentKey');
+      const orderId = urlParams.get('orderId');
+      const amount = urlParams.get('amount');
+      const paymentType = urlParams.get('paymentType');
+
+      fetch('/api/pay/validate', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          "paymentKey": paymentKey,
+          "orderId": orderId,
+          "amount": amount,
+          "paymentType": paymentType
+        })
+      }).then((response) => {
+        if (response.status === 200) {
+          window.location.href = '/pay/success';
+        }
+        else {
+          alert("결제가 승인되지 않았습니다");
+          window.location.href = '/pay/fail';
+        }
+      }).catch((error) => {
+        console.error(error);
+      });
+    })
+  </script>
+</body>
+</html>

--- a/src/main/resources/templates/pay-success.html
+++ b/src/main/resources/templates/pay-success.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>결제 성공</title>
+</head>
+<body>
+  <span>결제가 성공하였습니다!</span>
+</body>
+</html>

--- a/src/main/resources/templates/pay.html
+++ b/src/main/resources/templates/pay.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <!-- 결제위젯 SDK 추가 -->
+  <script src="https://js.tosspayments.com/v1/payment-widget"></script>
+  <title>결제하기</title>
+</head>
+<body>
+  <div>
+    <span>총 결제 금액: </span>
+    <span id="payment-value"></span>
+  </div>
+  <!-- 결제위젯, 이용약관 영역 -->
+  <div id="payment-method"></div>
+  <div id="agreement"></div>
+  <!-- 결제하기 버튼 -->
+  <button id="payment-button">결제하기</button>
+  <script>
+    const money = 15000;
+    document.getElementById("payment-value").innerText = money + "원";
+
+    const clientKey = "test_ck_D5GePWvyJnrK0W0k6q8gLzN97Eoq"
+    const customerKey = "aB7WwWjcDeHkNUmCmeFkY" // 내 상점에서 고객을 구분하기 위해 발급한 고객의 고유 ID
+    const button = document.getElementById("payment-button")
+    // ------  결제위젯 초기화 ------
+    // 비회원 결제에는 customerKey 대신 ANONYMOUS를 사용하세요.
+    const paymentWidget = PaymentWidget(clientKey, customerKey) // 회원 결제
+    // const paymentWidget = PaymentWidget(clientKey, PaymentWidget.ANONYMOUS) // 비회원 결제
+    // ------  결제위젯 렌더링 ------
+    // 결제수단 UI를 렌더링할 위치를 지정합니다. `#payment-method`와 같은 CSS 선택자와 결제 금액 객체를 추가하세요.
+    // DOM이 생성된 이후에 렌더링 메서드를 호출하세요.
+    // https://docs.tosspayments.com/reference/widget-sdk#renderpaymentmethods선택자-결제-금액-옵션
+    paymentWidget.renderPaymentMethods("#payment-method", { value: 15000 })
+    // ------  이용약관 렌더링 ------
+    // 이용약관 UI를 렌더링할 위치를 지정합니다. `#agreement`와 같은 CSS 선택자를 추가하세요.
+    // https://docs.tosspayments.com/reference/widget-sdk#renderagreement선택자
+    paymentWidget.renderAgreement('#agreement')
+    // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
+    // 더 많은 결제 정보 파라미터는 결제위젯 SDK에서 확인하세요.
+    // https://docs.tosspayments.com/reference/widget-sdk#requestpayment결제-정보
+    button.addEventListener("click", function () {
+
+      fetch('/api/pay', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({"orderId": 1, "price": 1000})
+      }).then((response) => {
+        return response.json();
+      }).then((data) => {
+        console.log(data);
+        paymentWidget.requestPayment({
+          orderId: data.encodedOrderId,
+          orderName: data.orderName,
+          successUrl: data.successUrl,
+          failUrl: data.failUrl,
+          customerEmail: data.customerEmail,
+          customerName: data.customerName
+        })
+      }).catch((error) => {
+        console.error(error);
+      });
+    })
+  </script>
+</body>
+</html>

--- a/src/main/resources/templates/pay.html
+++ b/src/main/resources/templates/pay.html
@@ -16,6 +16,11 @@
   <div id="agreement"></div>
   <!-- 결제하기 버튼 -->
   <button id="payment-button">결제하기</button>
+  <label for="orderId">주문 id</label>
+  <input class="text-input mb-10" type="text" id="orderId" name="orderId">
+
+  <label for="orderName">주문 이름</label>
+  <input class="text-input mb-10" type="text" id="orderName" name="orderName">
   <script>
     const money = 15000;
     document.getElementById("payment-value").innerText = money + "원";
@@ -46,7 +51,10 @@
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({"orderId": 1, "price": 1000})
+        body: JSON.stringify({
+          "orderId": document.getElementById("orderId").value,
+          "price": money,
+          "orderName": document.getElementById("orderName").value})
       }).then((response) => {
         return response.json();
       }).then((data) => {

--- a/src/main/resources/templates/pay.html
+++ b/src/main/resources/templates/pay.html
@@ -58,7 +58,6 @@
       }).then((response) => {
         return response.json();
       }).then((data) => {
-        console.log(data);
         paymentWidget.requestPayment({
           orderId: data.encodedOrderId,
           orderName: data.orderName,

--- a/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
@@ -1,0 +1,41 @@
+package com.gugucon.shopping.pay.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Pay 단위 테스트")
+class PayTest {
+
+    @Test
+    @DisplayName("결제 객체를 생성한다")
+    void create() {
+        assertThatNoException().isThrownBy(() -> new Pay(1L, "주문 이름", 1000L));
+    }
+
+    @Test
+    @DisplayName("금액이 같은지 확인한다")
+    void validateMoneySuccess_PriceSame() {
+        // given
+        Pay pay = new Pay(1L, "주문 이름", 1000L);
+
+        // when & then
+        assertThatNoException().isThrownBy(() -> pay.validateMoney(1000));
+    }
+
+    @Test
+    @DisplayName("금액이 같은지 확인하고 다르면 예외를 던진다")
+    void validateMoneyFail_PriceDifferent() {
+        // given
+        Pay pay = new Pay(1L, "주문 이름", 1000L);
+
+        // when
+        Exception exception = catchException(() -> pay.validateMoney(500));
+
+        // then
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
@@ -13,14 +13,14 @@ class PayTest {
     @Test
     @DisplayName("결제 객체를 생성한다")
     void create() {
-        assertThatNoException().isThrownBy(() -> new Pay(1L, "주문 이름", 1000L));
+        assertThatNoException().isThrownBy(() -> new Pay(1L, "인코딩", "주문 이름", 1000L));
     }
 
     @Test
     @DisplayName("금액이 같은지 확인한다")
     void validateMoneySuccess_PriceSame() {
         // given
-        Pay pay = new Pay(1L, "주문 이름", 1000L);
+        Pay pay = new Pay(1L, "인코딩", "주문 이름", 1000L);
 
         // when & then
         assertThatNoException().isThrownBy(() -> pay.validateMoney(1000));
@@ -30,7 +30,7 @@ class PayTest {
     @DisplayName("금액이 같은지 확인하고 다르면 예외를 던진다")
     void validateMoneyFail_PriceDifferent() {
         // given
-        Pay pay = new Pay(1L, "주문 이름", 1000L);
+        Pay pay = new Pay(1L, "인코딩", "주문 이름", 1000L);
 
         // when
         Exception exception = catchException(() -> pay.validateMoney(500));

--- a/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
@@ -33,7 +33,7 @@ class PayTest {
                      .build();
 
         // when & then
-        assertThatNoException().isThrownBy(() -> pay.validateMoney(1000));
+        assertThatNoException().isThrownBy(() -> pay.validateMoney(1000L));
     }
 
     @Test
@@ -48,7 +48,7 @@ class PayTest {
                      .build();
 
         // when
-        Exception exception = catchException(() -> pay.validateMoney(500));
+        Exception exception = catchException(() -> pay.validateMoney(500L));
 
         // then
         assertThat(exception).isInstanceOf(RuntimeException.class);

--- a/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
@@ -13,14 +13,24 @@ class PayTest {
     @Test
     @DisplayName("결제 객체를 생성한다")
     void create() {
-        assertThatNoException().isThrownBy(() -> new Pay(1L, "인코딩", "주문 이름", 1000L));
+        assertThatNoException().isThrownBy(() -> Pay.builder()
+                                     .orderId(1L)
+                                     .encodedOrderId("인코딩")
+                                     .orderName("주문 이름")
+                                     .price(1000L)
+                                     .build());
     }
 
     @Test
     @DisplayName("금액이 같은지 확인한다")
     void validateMoneySuccess_PriceSame() {
         // given
-        Pay pay = new Pay(1L, "인코딩", "주문 이름", 1000L);
+        Pay pay = Pay.builder()
+                     .orderId(1L)
+                     .encodedOrderId("인코딩")
+                     .orderName("주문 이름")
+                     .price(1000L)
+                     .build();
 
         // when & then
         assertThatNoException().isThrownBy(() -> pay.validateMoney(1000));
@@ -30,7 +40,12 @@ class PayTest {
     @DisplayName("금액이 같은지 확인하고 다르면 예외를 던진다")
     void validateMoneyFail_PriceDifferent() {
         // given
-        Pay pay = new Pay(1L, "인코딩", "주문 이름", 1000L);
+        Pay pay = Pay.builder()
+                     .orderId(1L)
+                     .encodedOrderId("인코딩")
+                     .orderName("주문 이름")
+                     .price(1000L)
+                     .build();
 
         // when
         Exception exception = catchException(() -> pay.validateMoney(500));

--- a/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/domain/PayTest.java
@@ -15,7 +15,6 @@ class PayTest {
     void create() {
         assertThatNoException().isThrownBy(() -> Pay.builder()
                                      .orderId(1L)
-                                     .encodedOrderId("인코딩")
                                      .orderName("주문 이름")
                                      .price(1000L)
                                      .build());
@@ -27,7 +26,6 @@ class PayTest {
         // given
         Pay pay = Pay.builder()
                      .orderId(1L)
-                     .encodedOrderId("인코딩")
                      .orderName("주문 이름")
                      .price(1000L)
                      .build();
@@ -42,7 +40,6 @@ class PayTest {
         // given
         Pay pay = Pay.builder()
                      .orderId(1L)
-                     .encodedOrderId("인코딩")
                      .orderName("주문 이름")
                      .price(1000L)
                      .build();

--- a/src/test/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64TranslatorTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64TranslatorTest.java
@@ -1,0 +1,41 @@
+package com.gugucon.shopping.pay.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("OrderIdBase64Translator 단위테스트")
+class OrderIdBase64TranslatorTest {
+
+    private final OrderIdTranslator orderIdTranslator = new OrderIdBase64Translator();
+
+    @Test
+    @DisplayName("인코딩한 내용을 디코딩하면 같은 내용이 된다")
+    void encodeAndDecodeSuccess_SameString() {
+        // given
+        Long orderId = 1L;
+        String orderName = "주문 이름";
+
+        // when
+        String encodedString = orderIdTranslator.encode(orderId, orderName);
+        Long decodeId = orderIdTranslator.decode(encodedString);
+
+        // then
+        assertThat(orderId).isEqualTo(decodeId);
+    }
+
+    @Test
+    @DisplayName("디코딩 불가능한 문자열을 받으면 예외를 던진다")
+    void decodeFail_NotAvailableString() {
+        // given
+        String notAvaliable = "not available";
+
+        // when
+        Exception exception = catchException(() -> orderIdTranslator.decode(notAvaliable));
+
+        // then
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/gugucon/shopping/pay/integration/IntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/integration/IntegrationTest.java
@@ -1,0 +1,23 @@
+package com.gugucon.shopping.pay.integration;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class IntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+}
+

--- a/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
@@ -5,18 +5,21 @@ import com.gugucon.shopping.pay.dto.PayResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
 @DisplayName("결제 인수 테스트")
 class PayIntegrationTest extends IntegrationTest {
 
     @Test
     @DisplayName("결제 데이터 검증을 요청한다.")
-    void payment() {
+    void createPayment() {
         // given
         PayRequest payRequest = new PayRequest(1L, 1000L);
 
@@ -35,5 +38,42 @@ class PayIntegrationTest extends IntegrationTest {
         assertThat(payResponse)
                 .extracting(PayResponse::getEncodedOrderId, PayResponse::getOrderName)
                 .containsExactly(String.valueOf(payRequest.getOrderId()), String.valueOf(payRequest.getOrderId()));
+    }
+
+    @Test
+    @DisplayName("결제 완료 후 검증 요청이 성공한다.")
+    void validatePaymentSuccess() {
+        // given
+        Map<String, Object> queryParam = new HashMap<>();
+        queryParam.put("paymentKey", "test");
+        queryParam.put("orderId", "testOrderId");
+        queryParam.put("amount", 10000);
+        queryParam.put("paymentType", "NORMAL");
+
+        // when & then
+        RestAssured
+                .given().log().all()
+                .queryParams(queryParam)
+                .when().get("/pay/success")
+                .then().log().all()
+                .body(containsString("결제"), containsString("성공"));
+    }
+
+    @Test
+    @DisplayName("결제 완료 후 검증 요청이 실패한다.")
+    void validatePaymentFail() {
+        // given
+        Map<String, Object> queryParam = new HashMap<>();
+        queryParam.put("code", "PAY_PROCESS_CANCELED");
+        queryParam.put("message", "사용자에 의해 결제가 취소되었습니다.");
+        queryParam.put("orderId", "testOrderId");
+
+        // when & then
+        RestAssured
+                .given().log().all()
+                .queryParams(queryParam)
+                .when().get("/pay/fail")
+                .then().log().all()
+                .body(containsString("결제"), containsString("실패"));
     }
 }

--- a/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
@@ -1,22 +1,23 @@
 package com.gugucon.shopping.pay.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
 
 import com.gugucon.shopping.pay.dto.PayRequest;
 import com.gugucon.shopping.pay.dto.PayResponse;
+import com.gugucon.shopping.pay.infrastructure.OrderIdTranslator;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 @DisplayName("결제 인수 테스트")
 class PayIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private OrderIdTranslator orderIdTranslator;
 
     @Test
     @DisplayName("결제 데이터 검증을 요청한다.")
@@ -38,45 +39,7 @@ class PayIntegrationTest extends IntegrationTest {
 
         // then
         PayResponse payResponse = response.as(PayResponse.class);
-        assertThat(payResponse)
-                .extracting(PayResponse::getEncodedOrderId, PayResponse::getOrderName)
-                .containsExactly(Base64.getEncoder().encodeToString((orderId + orderName).getBytes()), orderName);
-    }
-
-    @Test
-    @DisplayName("결제 완료 후 검증 요청이 성공한다.")
-    void validatePaymentSuccess() {
-        // given
-        Map<String, Object> queryParam = new HashMap<>();
-        queryParam.put("paymentKey", "test");
-        queryParam.put("orderId", "testOrderId");
-        queryParam.put("amount", 10000);
-        queryParam.put("paymentType", "NORMAL");
-
-        // when & then
-        RestAssured
-                .given().log().all()
-                .queryParams(queryParam)
-                .when().get("/pay/success")
-                .then().log().all()
-                .body(containsString("결제"), containsString("성공"));
-    }
-
-    @Test
-    @DisplayName("결제 완료 후 검증 요청이 실패한다.")
-    void validatePaymentFail() {
-        // given
-        Map<String, Object> queryParam = new HashMap<>();
-        queryParam.put("code", "PAY_PROCESS_CANCELED");
-        queryParam.put("message", "사용자에 의해 결제가 취소되었습니다.");
-        queryParam.put("orderId", "testOrderId");
-
-        // when & then
-        RestAssured
-                .given().log().all()
-                .queryParams(queryParam)
-                .when().get("/pay/fail")
-                .then().log().all()
-                .body(containsString("결제"), containsString("실패"));
+        assertThat(orderIdTranslator.decode(payResponse.getEncodedOrderId())).isEqualTo(orderId);
+        assertThat(payResponse.getOrderName()).isEqualTo(orderName);
     }
 }

--- a/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.gugucon.shopping.pay.integration;
+
+import com.gugucon.shopping.pay.dto.PayRequest;
+import com.gugucon.shopping.pay.dto.PayResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("결제 인수 테스트")
+class PayIntegrationTest extends IntegrationTest {
+
+    @Test
+    @DisplayName("결제 데이터 검증을 요청한다.")
+    void payment() {
+        // given
+        PayRequest payRequest = new PayRequest(1L, 1000L);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .body(payRequest)
+                .when().post("/api/pay")
+                .then().log().all()
+                .extract();
+
+        // then
+        PayResponse payResponse = response.as(PayResponse.class);
+        assertThat(payResponse)
+                .extracting(PayResponse::getEncodedOrderId, PayResponse::getOrderName)
+                .containsExactly(String.valueOf(payRequest.getOrderId()), String.valueOf(payRequest.getOrderId()));
+    }
+}

--- a/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/integration/PayIntegrationTest.java
@@ -1,18 +1,19 @@
 package com.gugucon.shopping.pay.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
 import com.gugucon.shopping.pay.dto.PayRequest;
 import com.gugucon.shopping.pay.dto.PayResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
 
 @DisplayName("결제 인수 테스트")
 class PayIntegrationTest extends IntegrationTest {
@@ -21,7 +22,9 @@ class PayIntegrationTest extends IntegrationTest {
     @DisplayName("결제 데이터 검증을 요청한다.")
     void createPayment() {
         // given
-        PayRequest payRequest = new PayRequest(1L, 1000L);
+        Long orderId = 1L;
+        String orderName = "대충 주문 이름";
+        PayRequest payRequest = new PayRequest(1L, 1000L, orderName);
 
         // when
         ExtractableResponse<Response> response = RestAssured
@@ -37,7 +40,7 @@ class PayIntegrationTest extends IntegrationTest {
         PayResponse payResponse = response.as(PayResponse.class);
         assertThat(payResponse)
                 .extracting(PayResponse::getEncodedOrderId, PayResponse::getOrderName)
-                .containsExactly(String.valueOf(payRequest.getOrderId()), String.valueOf(payRequest.getOrderId()));
+                .containsExactly(Base64.getEncoder().encodeToString((orderId + orderName).getBytes()), orderName);
     }
 
     @Test


### PR DESCRIPTION
## 🔗 관련 이슈

#3

## 🔔 주요 사항

- 외부 API에 결제 요청 구현
- 결제 페이지 구현
- 결제 후 승인 구현

## 🤔 의논 사항 또는 질문

- 추가적으로 해야할 일
  - 현재는 전부 RuntimeException으로 되어있는 예외처리 ErrorCode 추가 및 연동하기
  - PayController에서 페이지 연동은 PayPageController로 분리하기
  - 결제 외부 API 승인시 예외 처리하기
  - 기존 주문, 회원 정보 연동하기
    - orderId를 기존 주문에서 가져오기
    - PayResponse의 customerEmail, customerName 회원 정보에서 가져오기
  - 주문에 이름 부여하기
    - orderName 항목에 주문 이름 넣어주기
  - /pay 페이지 주문 창과 통합하기
  - /pay를 테스트 페이지로 만들기
- 의논 사항
  - 통합 테스트가 어려워, 수기로 E2E 테스트해야함
