### PR TITLE
chore: CI 설정 파일 작성

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: JDK 11 설정
+    - name: JDK 17 설정
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         
     - name: gradlew에 실행 권한 부여

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -1,0 +1,59 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Gradle로 CI 구축
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: JDK 11 설정
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        
+    - name: gradlew에 실행 권한 부여
+      run: chmod +x gradlew
+
+    - name: 프로젝트 빌드 및 테스트
+      run: ./gradlew clean build
+
+    - name: 테스트 결과를 PR에 코멘트로 등록
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      if: always()
+      with:
+        files: '**/build/test-results/test/TEST-*.xml'
+
+    - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록
+      uses: mikepenz/action-junit-report@v3
+      if: always()
+      with:
+        report_paths: '**/build/test-results/test/TEST-*.xml'
+        token: ${{ github.token }}
+
+    - name: 빌드 실패 시 Slack으로 알림
+      uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        author_name: 빌드 실패 알림
+        fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      if: failure()

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -14,7 +14,7 @@ on:
     branches: [ "main", "develop" ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -14,7 +14,10 @@ on:
     branches: [ "main", "develop" ]
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: write
 
 jobs:
   build:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -46,7 +46,7 @@ jobs:
       if: always()
       with:
         report_paths: '**/build/test-results/test/TEST-*.xml'
-        token: ${{ github.token }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: 빌드 실패 시 Slack으로 알림
       uses: 8398a7/action-slack@v3


### PR DESCRIPTION
## 🔗 관련 이슈

#11 

## 🔔 주요 사항

- `main`, `develop` 브랜치에 PR을 요청하거나 push할 때 테스트를 포함한 빌드가 이루어짐
- 테스트 결과를 파일로 저장
- 테스트 실패 시 slack으로 알림 전송

## 🤔 의논 사항 또는 질문

- 빌드를 위해 application.yaml 등 비밀로 설정된 내용을 Github Actions가 읽을 수 있도록 처리 필요

