### PR TITLE
test: 테스트 내 반복적인 회원가입 단순한 메소드로 변경

### DIFF
--- a/src/test/java/com/gugucon/shopping/TestUtils.java
+++ b/src/test/java/com/gugucon/shopping/TestUtils.java
@@ -2,27 +2,10 @@ package com.gugucon.shopping;
 
 import com.gugucon.shopping.item.domain.entity.CartItem;
 import com.gugucon.shopping.item.domain.entity.Product;
-import com.gugucon.shopping.item.dto.request.CartItemInsertRequest;
-import com.gugucon.shopping.item.dto.request.CartItemUpdateRequest;
-import com.gugucon.shopping.item.dto.response.CartItemResponse;
 import com.gugucon.shopping.member.domain.entity.Member;
 import com.gugucon.shopping.member.domain.vo.Password;
-import com.gugucon.shopping.member.dto.request.LoginRequest;
-import com.gugucon.shopping.member.dto.request.SignupRequest;
-import com.gugucon.shopping.member.dto.response.LoginResponse;
-import com.gugucon.shopping.pay.dto.request.PayCreateRequest;
-import com.gugucon.shopping.pay.dto.request.PayValidationRequest;
-import com.gugucon.shopping.pay.dto.response.PayCreateResponse;
-import com.gugucon.shopping.pay.dto.response.PayInfoResponse;
-import com.gugucon.shopping.pay.dto.response.PayValidationResponse;
-import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.List;
 
 public class TestUtils {
 
@@ -85,124 +68,5 @@ public class TestUtils {
                 .build();
     }
 
-    public static String login(final LoginRequest loginRequest) {
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(loginRequest)
-                .when().post("/api/v1/login/token")
-                .then().log().all()
-                .extract()
-                .as(LoginResponse.class)
-                .getAccessToken();
-    }
 
-    public static void signup(final SignupRequest signupRequest) {
-        RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(signupRequest)
-                .when().post("/api/v1/signup")
-                .then().log().all();
-    }
-
-    public static ExtractableResponse<Response> insertCartItem(final String accessToken,
-                                                               final CartItemInsertRequest cartItemInsertRequest) {
-        return RestAssured
-                .given().log().all()
-                .auth().oauth2(accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(cartItemInsertRequest)
-                .when().post("/api/v1/cart/items")
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> updateCartItem(final String accessToken,
-                                                               final long cartItemId,
-                                                               final CartItemUpdateRequest cartItemUpdateRequest) {
-        return RestAssured
-                .given().log().all()
-                .auth().oauth2(accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(cartItemUpdateRequest)
-                .when().put("/api/v1/cart/items/{cartItemId}/quantity", cartItemId)
-                .then().log().all()
-                .extract();
-    }
-
-    public static List<CartItemResponse> readCartItems(final String accessToken) {
-        return RestAssured
-                .given().log().all()
-                .auth().oauth2(accessToken)
-                .when().get("/api/v1/cart/items")
-                .then().log().all()
-                .extract()
-                .jsonPath()
-                .getList(".", CartItemResponse.class);
-    }
-
-    public static Long placeOrder(final String accessToken) {
-        final ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .auth().oauth2(accessToken)
-                .when()
-                .post("/api/v1/order")
-                .then().log().all()
-                .extract();
-        return Long.parseLong(response.header("Location").split("/")[2]);
-    }
-
-    public static Long createPayment(final String accessToken, final PayCreateRequest payCreateRequest) {
-        return RestAssured
-                .given().log().all()
-                .auth().oauth2(accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(payCreateRequest)
-                .when()
-                .put("/api/v1/pay")
-                .then().log().all()
-                .extract()
-                .as(PayCreateResponse.class)
-                .getPayId();
-    }
-
-    public static PayInfoResponse getPaymentInfo(final String accessToken, final Long payId) {
-        return RestAssured
-                .given().log().all()
-                .auth().oauth2(accessToken)
-                .when()
-                .get("/api/v1/pay/{payId}", payId)
-                .then().log().all()
-                .extract()
-                .as(PayInfoResponse.class);
-    }
-
-    public static Long validatePayment(final String accessToken, final PayValidationRequest payValidationRequest) {
-        return RestAssured
-                .given().log().all()
-                .auth().oauth2(accessToken)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(payValidationRequest)
-                .when()
-                .post("/api/v1/pay/validate")
-                .then().log().all()
-                .extract()
-                .as(PayValidationResponse.class)
-                .getOrderId();
-    }
-
-    public static Long buyProduct(final String accessToken, final Long productId, final int quantity) {
-        insertCartItem(accessToken, new CartItemInsertRequest(productId));
-        final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
-        updateCartItem(accessToken, cartItemResponses.get(0).getCartItemId(), new CartItemUpdateRequest(quantity));
-        final Long orderId = placeOrder(accessToken);
-        final Long payId = createPayment(accessToken, new PayCreateRequest(orderId));
-        final PayInfoResponse payInfoResponse = getPaymentInfo(accessToken, payId);
-        final PayValidationRequest payValidationRequest = new PayValidationRequest("mockPaymentKey",
-                                                                                   payInfoResponse.getEncodedOrderId(),
-                                                                                   payInfoResponse.getPrice(),
-                                                                                   "mockPaymentType");
-        return validatePayment(accessToken, payValidationRequest);
-    }
 }

--- a/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
@@ -1,15 +1,13 @@
 package com.gugucon.shopping.integration;
 
-import static com.gugucon.shopping.utils.ApiUtils.signUp;
+import static com.gugucon.shopping.utils.ApiUtils.loginAfterSignUp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
 import com.gugucon.shopping.item.dto.request.CartItemInsertRequest;
-import com.gugucon.shopping.member.dto.request.LoginRequest;
 import com.gugucon.shopping.member.repository.MemberRepository;
-import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -36,10 +34,7 @@ class AuthIntegrationTest {
     @DisplayName("jwt 토큰 인증에 성공한다")
     void authenticate() {
         // given
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        signUp(email, password);
-        String accessToken = ApiUtils.login(new LoginRequest(email, password));
+        String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         // when
         final ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.gugucon.shopping.integration;
 
+import static com.gugucon.shopping.utils.ApiUtils.signUp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gugucon.shopping.common.exception.ErrorCode;
@@ -7,7 +8,6 @@ import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
 import com.gugucon.shopping.item.dto.request.CartItemInsertRequest;
 import com.gugucon.shopping.member.dto.request.LoginRequest;
-import com.gugucon.shopping.member.dto.request.SignupRequest;
 import com.gugucon.shopping.member.repository.MemberRepository;
 import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
@@ -76,10 +76,5 @@ class AuthIntegrationTest {
         final ErrorResponse errorResponse = response.as(ErrorResponse.class);
         assertThat(errorResponse.getErrorCode()).isEqualTo(ErrorCode.LOGIN_REQUESTED);
         assertThat(errorResponse.getMessage()).isEqualTo(ErrorCode.LOGIN_REQUESTED.getMessage());
-    }
-
-    private void signUp(final String email, final String password) {
-        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        ApiUtils.signup(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
@@ -2,7 +2,6 @@ package com.gugucon.shopping.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
@@ -10,6 +9,7 @@ import com.gugucon.shopping.item.dto.request.CartItemInsertRequest;
 import com.gugucon.shopping.member.dto.request.LoginRequest;
 import com.gugucon.shopping.member.dto.request.SignupRequest;
 import com.gugucon.shopping.member.repository.MemberRepository;
+import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -39,7 +39,7 @@ class AuthIntegrationTest {
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
         signUp(email, password);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = ApiUtils.login(new LoginRequest(email, password));
 
         // when
         final ExtractableResponse<Response> response = RestAssured
@@ -80,6 +80,6 @@ class AuthIntegrationTest {
 
     private void signUp(final String email, final String password) {
         final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        TestUtils.signup(request);
+        ApiUtils.signup(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/AuthIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.gugucon.shopping.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
@@ -17,8 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
 @DisplayName("jwt 토큰 인증 기능 통합 테스트")
@@ -38,8 +38,7 @@ class AuthIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
+        signUp(email, password);
         String accessToken = TestUtils.login(new LoginRequest(email, password));
 
         // when
@@ -77,5 +76,10 @@ class AuthIntegrationTest {
         final ErrorResponse errorResponse = response.as(ErrorResponse.class);
         assertThat(errorResponse.getErrorCode()).isEqualTo(ErrorCode.LOGIN_REQUESTED);
         assertThat(errorResponse.getMessage()).isEqualTo(ErrorCode.LOGIN_REQUESTED.getMessage());
+    }
+
+    private void signUp(final String email, final String password) {
+        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
+        TestUtils.signup(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
@@ -1,10 +1,9 @@
 package com.gugucon.shopping.integration;
 
-import static com.gugucon.shopping.TestUtils.insertCartItem;
-import static com.gugucon.shopping.TestUtils.readCartItems;
+import static com.gugucon.shopping.utils.ApiUtils.insertCartItem;
+import static com.gugucon.shopping.utils.ApiUtils.readCartItems;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
@@ -15,6 +14,7 @@ import com.gugucon.shopping.item.repository.CartItemRepository;
 import com.gugucon.shopping.member.dto.request.LoginRequest;
 import com.gugucon.shopping.member.dto.request.SignupRequest;
 import com.gugucon.shopping.member.repository.MemberRepository;
+import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -401,12 +401,12 @@ class CartIntegrationTest {
 
     private void signUp(final String email, final String password) {
         final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        TestUtils.signup(request);
+        ApiUtils.signup(request);
     }
 
     private String signUpAndLogin(final String email, final String password) {
         signUp(email, password);
         final LoginRequest request = new LoginRequest(email, password);
-        return TestUtils.login(request);
+        return ApiUtils.login(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
@@ -1,5 +1,9 @@
 package com.gugucon.shopping.integration;
 
+import static com.gugucon.shopping.TestUtils.insertCartItem;
+import static com.gugucon.shopping.TestUtils.readCartItems;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
@@ -14,18 +18,13 @@ import com.gugucon.shopping.member.repository.MemberRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.List;
-
-import static com.gugucon.shopping.TestUtils.insertCartItem;
-import static com.gugucon.shopping.TestUtils.readCartItems;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
 @DisplayName("장바구니 기능 통합 테스트")
@@ -49,10 +48,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(1L);
 
@@ -76,10 +72,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
 
@@ -105,10 +98,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(null);
 
@@ -134,10 +124,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         final Long invalidProductId = Long.MAX_VALUE;
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(invalidProductId);
@@ -164,10 +151,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         final Long soldOutProductId = 4L;
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(soldOutProductId);
@@ -194,10 +178,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         insertCartItem(accessToken, new CartItemInsertRequest(2L));
@@ -224,10 +205,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -256,10 +234,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -288,10 +263,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -320,9 +292,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -356,9 +326,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -387,9 +355,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         final Long invalidCartItemId = Long.MAX_VALUE;
         final CartItemUpdateRequest cartItemUpdateRequest = new CartItemUpdateRequest(3);
@@ -416,9 +382,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -444,10 +408,7 @@ class CartIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured
@@ -467,5 +428,16 @@ class CartIntegrationTest {
         return cartItemResponses.stream()
                 .map(CartItemResponse::getName)
                 .toList();
+    }
+
+    private void signUp(final String email, final String password) {
+        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
+        TestUtils.signup(request);
+    }
+
+    private String signUpAndLogin(final String email, final String password) {
+        signUp(email, password);
+        final LoginRequest request = new LoginRequest(email, password);
+        return TestUtils.login(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
@@ -46,9 +46,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니에 상품을 추가한다.")
     void insertCartItem_() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(1L);
 
@@ -70,9 +68,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니에 같은 상품이 들어 있으면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_duplicateItem() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
 
@@ -96,9 +92,7 @@ class CartIntegrationTest {
     @DisplayName("productId가 없으면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_withoutProductId() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(null);
 
@@ -122,9 +116,7 @@ class CartIntegrationTest {
     @DisplayName("존재하지 않는 상품이면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_invalidProduct() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         final Long invalidProductId = Long.MAX_VALUE;
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(invalidProductId);
@@ -149,9 +141,7 @@ class CartIntegrationTest {
     @DisplayName("품절된 상품이면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_soldOutProduct() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         final Long soldOutProductId = 4L;
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(soldOutProductId);
@@ -176,9 +166,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품 목록을 조회한다")
     void readCartItems_() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         insertCartItem(accessToken, new CartItemInsertRequest(2L));
@@ -192,7 +180,7 @@ class CartIntegrationTest {
                 .extract();
 
         /* then */
-        List<CartItemResponse> cartItemResponses = response.jsonPath()
+        final List<CartItemResponse> cartItemResponses = response.jsonPath()
                 .getList(".", CartItemResponse.class);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(toProductNames(cartItemResponses)).containsExactly("치킨", "피자");
@@ -203,9 +191,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품 하나의 수량을 수정한다.")
     void updateCartItemQuantity() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -232,9 +218,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품 수량을 0으로 수정하면 삭제된다.")
     void updateCartItemQuantityToZero() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -261,9 +245,7 @@ class CartIntegrationTest {
     @DisplayName("변경 수량이 0 미만이면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_quantityUnderZero() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -290,19 +272,14 @@ class CartIntegrationTest {
     @DisplayName("다른 사용자의 장바구니 상품이면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_cartItemOfOtherUser() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
         final Long cartItemId = cartItemResponses.get(0).getCartItemId();
         final CartItemUpdateRequest cartItemUpdateRequest = new CartItemUpdateRequest(3);
-        final String otherEmail = "other_test_email@woowafriends.com";
-        final String otherPassword = "test_password!";
-        final String otherNickname = "tester2";
-        TestUtils.signup(new SignupRequest(otherEmail, otherPassword, otherPassword, otherNickname));
-        String otherAccessToken = TestUtils.login(new LoginRequest(otherEmail, otherPassword));
+
+        final String otherAccessToken = signUpAndLogin("other_test_email@woowafriends.com", "test_password!");
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured
@@ -324,9 +301,7 @@ class CartIntegrationTest {
     @DisplayName("변경 수량 정보가 없으면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_withoutQuantity() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -353,9 +328,7 @@ class CartIntegrationTest {
     @DisplayName("존재하지 않는 장바구니 상품이면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_invalidCartItemId() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         final Long invalidCartItemId = Long.MAX_VALUE;
         final CartItemUpdateRequest cartItemUpdateRequest = new CartItemUpdateRequest(3);
@@ -380,9 +353,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품을 삭제한다.")
     void removeCartItem() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -406,9 +377,7 @@ class CartIntegrationTest {
     @DisplayName("존재하지 않는 장바구니 상품을 삭제할 때 400 상태코드를 응답한다.")
     void removeCartItem_productNotExist() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/CartIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.gugucon.shopping.integration;
 
 import static com.gugucon.shopping.utils.ApiUtils.insertCartItem;
+import static com.gugucon.shopping.utils.ApiUtils.loginAfterSignUp;
 import static com.gugucon.shopping.utils.ApiUtils.readCartItems;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,10 +12,7 @@ import com.gugucon.shopping.item.dto.request.CartItemInsertRequest;
 import com.gugucon.shopping.item.dto.request.CartItemUpdateRequest;
 import com.gugucon.shopping.item.dto.response.CartItemResponse;
 import com.gugucon.shopping.item.repository.CartItemRepository;
-import com.gugucon.shopping.member.dto.request.LoginRequest;
-import com.gugucon.shopping.member.dto.request.SignupRequest;
 import com.gugucon.shopping.member.repository.MemberRepository;
-import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -46,7 +44,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니에 상품을 추가한다.")
     void insertCartItem_() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(1L);
 
@@ -68,7 +66,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니에 같은 상품이 들어 있으면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_duplicateItem() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
 
@@ -92,7 +90,7 @@ class CartIntegrationTest {
     @DisplayName("productId가 없으면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_withoutProductId() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(null);
 
@@ -116,7 +114,7 @@ class CartIntegrationTest {
     @DisplayName("존재하지 않는 상품이면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_invalidProduct() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         final Long invalidProductId = Long.MAX_VALUE;
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(invalidProductId);
@@ -141,7 +139,7 @@ class CartIntegrationTest {
     @DisplayName("품절된 상품이면 장바구니 상품 추가를 요청했을 때 400 상태코드를 응답한다.")
     void insertCartItemFail_soldOutProduct() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         final Long soldOutProductId = 4L;
         final CartItemInsertRequest cartItemInsertRequest = new CartItemInsertRequest(soldOutProductId);
@@ -166,7 +164,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품 목록을 조회한다")
     void readCartItems_() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         insertCartItem(accessToken, new CartItemInsertRequest(2L));
@@ -191,7 +189,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품 하나의 수량을 수정한다.")
     void updateCartItemQuantity() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -218,7 +216,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품 수량을 0으로 수정하면 삭제된다.")
     void updateCartItemQuantityToZero() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -245,7 +243,7 @@ class CartIntegrationTest {
     @DisplayName("변경 수량이 0 미만이면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_quantityUnderZero() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -272,14 +270,14 @@ class CartIntegrationTest {
     @DisplayName("다른 사용자의 장바구니 상품이면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_cartItemOfOtherUser() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
         final Long cartItemId = cartItemResponses.get(0).getCartItemId();
         final CartItemUpdateRequest cartItemUpdateRequest = new CartItemUpdateRequest(3);
 
-        final String otherAccessToken = signUpAndLogin("other_test_email@woowafriends.com", "test_password!");
+        final String otherAccessToken = loginAfterSignUp("other_test_email@woowafriends.com", "test_password!");
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured
@@ -301,7 +299,7 @@ class CartIntegrationTest {
     @DisplayName("변경 수량 정보가 없으면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_withoutQuantity() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -328,7 +326,7 @@ class CartIntegrationTest {
     @DisplayName("존재하지 않는 장바구니 상품이면 장바구니 상품 수량 변경을 요청했을 때 400 상태코드를 응답한다.")
     void updateCartItemQuantityFail_invalidCartItemId() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         final Long invalidCartItemId = Long.MAX_VALUE;
         final CartItemUpdateRequest cartItemUpdateRequest = new CartItemUpdateRequest(3);
@@ -353,7 +351,7 @@ class CartIntegrationTest {
     @DisplayName("장바구니 상품을 삭제한다.")
     void removeCartItem() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
@@ -377,7 +375,7 @@ class CartIntegrationTest {
     @DisplayName("존재하지 않는 장바구니 상품을 삭제할 때 400 상태코드를 응답한다.")
     void removeCartItem_productNotExist() {
         /* given */
-        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
+        final String accessToken = loginAfterSignUp("test_email@woowafriends.com", "test_password!");
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured
@@ -397,16 +395,5 @@ class CartIntegrationTest {
         return cartItemResponses.stream()
                 .map(CartItemResponse::getName)
                 .toList();
-    }
-
-    private void signUp(final String email, final String password) {
-        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        ApiUtils.signup(request);
-    }
-
-    private String signUpAndLogin(final String email, final String password) {
-        signUp(email, password);
-        final LoginRequest request = new LoginRequest(email, password);
-        return ApiUtils.login(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/LoginIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.gugucon.shopping.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
@@ -20,8 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @IntegrationTest
 @DisplayName("로그인 기능 통합 테스트")
 class LoginIntegrationTest {
@@ -40,9 +40,7 @@ class LoginIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
+        signUp(email, password);
         LoginRequest loginRequest = new LoginRequest(email, password);
 
         /* when */
@@ -89,9 +87,7 @@ class LoginIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
+        signUp(email, password);
         LoginRequest loginRequest = new LoginRequest(email, "invalid_password");
 
         /* when */
@@ -116,9 +112,7 @@ class LoginIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
+        signUp(email, password);
         LoginRequest loginRequest = new LoginRequest(loginEmail, password);
 
         /* when */
@@ -143,9 +137,7 @@ class LoginIntegrationTest {
         /* given */
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
+        signUp(email, password);
         LoginRequest loginRequest = new LoginRequest(email, loginPassword);
 
         /* when */
@@ -161,5 +153,10 @@ class LoginIntegrationTest {
         final ErrorResponse errorResponse = response.as(ErrorResponse.class);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         assertThat(errorResponse.getErrorCode()).isEqualTo(ErrorCode.REQUIRED_FIELD_MISSING);
+    }
+
+    private void signUp(final String email, final String password) {
+        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
+        TestUtils.signup(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/LoginIntegrationTest.java
@@ -1,15 +1,14 @@
 package com.gugucon.shopping.integration;
 
+import static com.gugucon.shopping.utils.ApiUtils.signUp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
 import com.gugucon.shopping.member.dto.request.LoginRequest;
-import com.gugucon.shopping.member.dto.request.SignupRequest;
 import com.gugucon.shopping.member.dto.response.LoginResponse;
 import com.gugucon.shopping.member.repository.MemberRepository;
-import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -153,10 +152,5 @@ class LoginIntegrationTest {
         final ErrorResponse errorResponse = response.as(ErrorResponse.class);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         assertThat(errorResponse.getErrorCode()).isEqualTo(ErrorCode.REQUIRED_FIELD_MISSING);
-    }
-
-    private void signUp(final String email, final String password) {
-        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        ApiUtils.signup(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/LoginIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/LoginIntegrationTest.java
@@ -2,7 +2,6 @@ package com.gugucon.shopping.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
@@ -10,6 +9,7 @@ import com.gugucon.shopping.member.dto.request.LoginRequest;
 import com.gugucon.shopping.member.dto.request.SignupRequest;
 import com.gugucon.shopping.member.dto.response.LoginResponse;
 import com.gugucon.shopping.member.repository.MemberRepository;
+import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -157,6 +157,6 @@ class LoginIntegrationTest {
 
     private void signUp(final String email, final String password) {
         final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        TestUtils.signup(request);
+        ApiUtils.signup(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/OrderIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/OrderIntegrationTest.java
@@ -1,12 +1,11 @@
 package com.gugucon.shopping.integration;
 
-import static com.gugucon.shopping.TestUtils.insertCartItem;
-import static com.gugucon.shopping.TestUtils.placeOrder;
-import static com.gugucon.shopping.TestUtils.readCartItems;
-import static com.gugucon.shopping.TestUtils.updateCartItem;
+import static com.gugucon.shopping.utils.ApiUtils.insertCartItem;
+import static com.gugucon.shopping.utils.ApiUtils.placeOrder;
+import static com.gugucon.shopping.utils.ApiUtils.readCartItems;
+import static com.gugucon.shopping.utils.ApiUtils.updateCartItem;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
@@ -24,6 +23,7 @@ import com.gugucon.shopping.order.dto.response.OrderDetailResponse;
 import com.gugucon.shopping.order.dto.response.OrderItemResponse;
 import com.gugucon.shopping.order.repository.OrderItemRepository;
 import com.gugucon.shopping.order.repository.OrderRepository;
+import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -250,12 +250,12 @@ class OrderIntegrationTest {
 
     private void signUp(final String email, final String password) {
         final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        TestUtils.signup(request);
+        ApiUtils.signup(request);
     }
 
     private String signUpAndLogin(final String email, final String password) {
         signUp(email, password);
         final LoginRequest request = new LoginRequest(email, password);
-        return TestUtils.login(request);
+        return ApiUtils.login(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/OrderIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/OrderIntegrationTest.java
@@ -72,9 +72,7 @@ class OrderIntegrationTest {
     @DisplayName("주문한다.")
     void order() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
 
         /* when */
@@ -95,9 +93,7 @@ class OrderIntegrationTest {
     @DisplayName("장바구니가 비어 있으면 주문을 요청했을 때 400 상태코드를 응답한다.")
     void orderFail_emptyCart() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured
@@ -119,8 +115,7 @@ class OrderIntegrationTest {
     void orderFail_soldOutProduct() {
         /* given */
         final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin(email, "test_password!");
 
         final Long memberId = memberRepository.findByEmail(Email.from(email)).orElseThrow().getId();
         cartItemRepository.save(CartItem.builder()
@@ -148,9 +143,7 @@ class OrderIntegrationTest {
     @DisplayName("주문을 요청했을 때 재고가 부족하면 400 상태코드를 응답한다.")
     void orderFail_lackOfStock() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long cartItemId = readCartItems(accessToken).get(0).getCartItemId();
@@ -176,9 +169,7 @@ class OrderIntegrationTest {
     @DisplayName("주문 상세 정보를 조회한다.")
     void readOrderDetail() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         insertCartItem(accessToken, new CartItemInsertRequest(2L));
@@ -206,9 +197,7 @@ class OrderIntegrationTest {
     @DisplayName("존재하지 않는 주문이면 주문 상세정보 조회를 요청했을 때 400 상태코드를 응답한다.")
     void readOrderDetailFail_invalidOrderId() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         final Long invalidOrderId = Long.MAX_VALUE;
 
@@ -231,16 +220,12 @@ class OrderIntegrationTest {
     @DisplayName("다른 사용자의 주문이면 주문 상세정보 조회를 요청했을 때 400 상태코드를 응답한다.")
     void readOrderDetailFail_orderOfOtherUser() {
         /* given */
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
 
-        final String otherEmail = "other_test_email@woowafriends.com";
-        final String otherPassword = "test_password!";
-        String otherAccessToken = signUpAndLogin(otherEmail, otherPassword);
+        final String otherAccessToken = signUpAndLogin("other_test_email@woowafriends.com", "test_password!");
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/com/gugucon/shopping/integration/PayIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/PayIntegrationTest.java
@@ -1,5 +1,16 @@
 package com.gugucon.shopping.integration;
 
+import static com.gugucon.shopping.TestUtils.buyProduct;
+import static com.gugucon.shopping.TestUtils.createPayment;
+import static com.gugucon.shopping.TestUtils.getPaymentInfo;
+import static com.gugucon.shopping.TestUtils.insertCartItem;
+import static com.gugucon.shopping.TestUtils.placeOrder;
+import static com.gugucon.shopping.TestUtils.validatePayment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
 import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
@@ -30,12 +41,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
-
-import static com.gugucon.shopping.TestUtils.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 @IntegrationTest
 @DisplayName("결제 기능 통합 테스트")
@@ -70,9 +75,7 @@ class PayIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -101,9 +104,7 @@ class PayIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -123,8 +124,7 @@ class PayIntegrationTest {
         assertThat(payInfoResponse.getEncodedOrderId()).isNotEmpty();
         assertThat(payInfoResponse.getOrderName()).isEqualTo("치킨");
         assertThat(payInfoResponse.getPrice()).isEqualTo(20000);
-        assertThat(payInfoResponse.getCustomerEmail()).isEqualTo("test_email@woowafriends.com");
-        assertThat(payInfoResponse.getCustomerName()).isEqualTo("tester1");
+        assertThat(payInfoResponse.getCustomerEmail()).isEqualTo(email);
         assertThat(payInfoResponse.getCustomerKey()).isNotEmpty();
         assertThat(payInfoResponse.getSuccessUrl()).isEqualTo(successUrl);
         assertThat(payInfoResponse.getFailUrl()).isEqualTo(failUrl);
@@ -137,9 +137,7 @@ class PayIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -178,9 +176,7 @@ class PayIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -219,9 +215,7 @@ class PayIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(3L));
         final Long orderId = placeOrder(accessToken);
@@ -239,9 +233,7 @@ class PayIntegrationTest {
 
         final String otherEmail = "other_test_email@woowafriends.com";
         final String otherPassword = "test_password!";
-        final String otherNickname = "tester2";
-        TestUtils.signup(new SignupRequest(otherEmail, otherPassword, otherPassword, otherNickname));
-        String otherAccessToken = TestUtils.login(new LoginRequest(otherEmail, otherPassword));
+        String otherAccessToken = signUpAndLogin(otherEmail, otherPassword);
         buyProduct(otherAccessToken, 3L, 100);
 
         // when
@@ -267,9 +259,7 @@ class PayIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -310,9 +300,7 @@ class PayIntegrationTest {
         // given
         final String email = "test_email@woowafriends.com";
         final String password = "test_password!";
-        final String nickname = "tester1";
-        TestUtils.signup(new SignupRequest(email, password, password, nickname));
-        String accessToken = TestUtils.login(new LoginRequest(email, password));
+        String accessToken = signUpAndLogin(email, password);
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -330,9 +318,7 @@ class PayIntegrationTest {
 
         final String otherEmail = "other_test_email@woowafriends.com";
         final String otherPassword = "test_password!";
-        final String otherNickname = "tester2";
-        TestUtils.signup(new SignupRequest(otherEmail, otherPassword, otherPassword, otherNickname));
-        String otherAccessToken = TestUtils.login(new LoginRequest(otherEmail, otherPassword));
+        String otherAccessToken = signUpAndLogin(otherEmail, otherPassword);
 
         // when
         final ExtractableResponse<Response> response = RestAssured
@@ -349,5 +335,16 @@ class PayIntegrationTest {
         final ErrorResponse errorResponse = response.as(ErrorResponse.class);
         assertThat(errorResponse.getErrorCode()).isEqualTo(ErrorCode.INVALID_ORDER);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    private void signUp(final String email, final String password) {
+        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
+        TestUtils.signup(request);
+    }
+
+    private String signUpAndLogin(final String email, final String password) {
+        signUp(email, password);
+        final LoginRequest request = new LoginRequest(email, password);
+        return TestUtils.login(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/PayIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/PayIntegrationTest.java
@@ -73,9 +73,7 @@ class PayIntegrationTest {
     @DisplayName("주문에 대한 결제 정보를 생성한다.")
     void createPayment_() {
         // given
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -103,8 +101,7 @@ class PayIntegrationTest {
     void getPaymentInfo_() {
         // given
         final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin(email, "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -135,9 +132,7 @@ class PayIntegrationTest {
     @DisplayName("결제를 검증한다.")
     void validatePayment_() {
         // given
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -174,9 +169,7 @@ class PayIntegrationTest {
     @DisplayName("외부 API 검증 요청에 실패하면 결제 검증을 요청했을 때 500 상태코드를 반환한다.")
     void validatePaymentFail_externalValidationFail() {
         // given
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -213,9 +206,7 @@ class PayIntegrationTest {
     @DisplayName("재고가 부족하면 결제 검증을 요청했을 때 400 상태코드를 반환한다.")
     void validatePaymentFail_stockNotEnough() {
         // given
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(3L));
         final Long orderId = placeOrder(accessToken);
@@ -231,9 +222,7 @@ class PayIntegrationTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess("{ \"status\": \"DONE\" }", MediaType.APPLICATION_JSON));
 
-        final String otherEmail = "other_test_email@woowafriends.com";
-        final String otherPassword = "test_password!";
-        String otherAccessToken = signUpAndLogin(otherEmail, otherPassword);
+        final String otherAccessToken = signUpAndLogin("other_test_email@woowafriends.com", "test_password!");
         buyProduct(otherAccessToken, 3L, 100);
 
         // when
@@ -257,9 +246,7 @@ class PayIntegrationTest {
     @DisplayName("이미 결제가 완료되었으면 결제 검증을 요청했을 때 400 상태코드를 반환한다.")
     void validatePaymentFail_payedOrder() {
         // given
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -298,9 +285,7 @@ class PayIntegrationTest {
     @DisplayName("다른 회원의 주문에 대해 결제 검증을 요청했을 때 400 상태코드를 반환한다.")
     void validatePaymentFail_orderOfOtherMember() {
         // given
-        final String email = "test_email@woowafriends.com";
-        final String password = "test_password!";
-        String accessToken = signUpAndLogin(email, password);
+        final String accessToken = signUpAndLogin("test_email@woowafriends.com", "test_password!");
 
         insertCartItem(accessToken, new CartItemInsertRequest(1L));
         final Long orderId = placeOrder(accessToken);
@@ -316,9 +301,7 @@ class PayIntegrationTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess("{ \"status\": \"DONE\" }", MediaType.APPLICATION_JSON));
 
-        final String otherEmail = "other_test_email@woowafriends.com";
-        final String otherPassword = "test_password!";
-        String otherAccessToken = signUpAndLogin(otherEmail, otherPassword);
+        final String otherAccessToken = signUpAndLogin("other_test_email@woowafriends.com", "test_password!");
 
         // when
         final ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/com/gugucon/shopping/integration/PayIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/PayIntegrationTest.java
@@ -1,17 +1,16 @@
 package com.gugucon.shopping.integration;
 
-import static com.gugucon.shopping.TestUtils.buyProduct;
-import static com.gugucon.shopping.TestUtils.createPayment;
-import static com.gugucon.shopping.TestUtils.getPaymentInfo;
-import static com.gugucon.shopping.TestUtils.insertCartItem;
-import static com.gugucon.shopping.TestUtils.placeOrder;
-import static com.gugucon.shopping.TestUtils.validatePayment;
+import static com.gugucon.shopping.utils.ApiUtils.buyProduct;
+import static com.gugucon.shopping.utils.ApiUtils.createPayment;
+import static com.gugucon.shopping.utils.ApiUtils.getPaymentInfo;
+import static com.gugucon.shopping.utils.ApiUtils.insertCartItem;
+import static com.gugucon.shopping.utils.ApiUtils.placeOrder;
+import static com.gugucon.shopping.utils.ApiUtils.validatePayment;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
@@ -27,6 +26,7 @@ import com.gugucon.shopping.pay.dto.response.PayCreateResponse;
 import com.gugucon.shopping.pay.dto.response.PayInfoResponse;
 import com.gugucon.shopping.pay.dto.response.PayValidationResponse;
 import com.gugucon.shopping.pay.repository.PayRepository;
+import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -322,12 +322,12 @@ class PayIntegrationTest {
 
     private void signUp(final String email, final String password) {
         final SignupRequest request = new SignupRequest(email, password, password,"testUser");
-        TestUtils.signup(request);
+        ApiUtils.signup(request);
     }
 
     private String signUpAndLogin(final String email, final String password) {
         signUp(email, password);
         final LoginRequest request = new LoginRequest(email, password);
-        return TestUtils.login(request);
+        return ApiUtils.login(request);
     }
 }

--- a/src/test/java/com/gugucon/shopping/integration/SignupIntegrationTest.java
+++ b/src/test/java/com/gugucon/shopping/integration/SignupIntegrationTest.java
@@ -1,11 +1,13 @@
 package com.gugucon.shopping.integration;
 
-import com.gugucon.shopping.TestUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ErrorResponse;
 import com.gugucon.shopping.integration.config.IntegrationTest;
 import com.gugucon.shopping.member.dto.request.SignupRequest;
 import com.gugucon.shopping.member.repository.MemberRepository;
+import com.gugucon.shopping.utils.ApiUtils;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -18,8 +20,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
 @DisplayName("회원 가입 기능 통합 테스트")
@@ -63,7 +63,7 @@ class SignupIntegrationTest {
         final String password = "test_password!";
         final String nickname = "김동주";
         final SignupRequest signupRequest = new SignupRequest(email, password, password, nickname);
-        TestUtils.signup(signupRequest);
+        ApiUtils.signup(signupRequest);
 
         /* when */
         final ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/com/gugucon/shopping/item/domain/entity/CartItemTest.java
+++ b/src/test/java/com/gugucon/shopping/item/domain/entity/CartItemTest.java
@@ -1,17 +1,16 @@
 package com.gugucon.shopping.item.domain.entity;
 
-import com.gugucon.shopping.common.exception.ErrorCode;
-import com.gugucon.shopping.common.exception.ShoppingException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.math.BigInteger;
-
-import static com.gugucon.shopping.TestUtils.createProduct;
-import static com.gugucon.shopping.TestUtils.createSoldOutProduct;
+import static com.gugucon.shopping.utils.DomainUtils.createProduct;
+import static com.gugucon.shopping.utils.DomainUtils.createSoldOutProduct;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.gugucon.shopping.common.exception.ErrorCode;
+import com.gugucon.shopping.common.exception.ShoppingException;
+import java.math.BigInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 @DisplayName("CartItem 단위 테스트")
 class CartItemTest {

--- a/src/test/java/com/gugucon/shopping/item/domain/entity/ProductTest.java
+++ b/src/test/java/com/gugucon/shopping/item/domain/entity/ProductTest.java
@@ -1,17 +1,17 @@
 package com.gugucon.shopping.item.domain.entity;
 
-import com.gugucon.shopping.TestUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.gugucon.shopping.common.domain.vo.Quantity;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ShoppingException;
+import com.gugucon.shopping.utils.DomainUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("Product 단위 테스트")
 class ProductTest {
@@ -20,7 +20,7 @@ class ProductTest {
     @DisplayName("물품이 품절인지 검사한다.")
     void validateSoldOut() {
         // given
-        final Product product = TestUtils.createProduct("name", 1000L);
+        final Product product = DomainUtils.createProduct("name", 1000L);
 
         // when & then
         assertThatNoException().isThrownBy(product::validateSoldOut);
@@ -30,7 +30,7 @@ class ProductTest {
     @DisplayName("물품이 품절인지 검사할 때 품절이면 예외를 반환한다.")
     void validateSoldOut_isSoldOut() {
         // given
-        final Product product = TestUtils.createSoldOutProduct("name", 1000L);
+        final Product product = DomainUtils.createSoldOutProduct("name", 1000L);
 
         // when & then
         final ShoppingException exception = assertThrows(ShoppingException.class, product::validateSoldOut);
@@ -42,7 +42,7 @@ class ProductTest {
     @DisplayName("요청한 수량으로 재고를 줄일 수 있으면 true를 반환한다.")
     void canReduceStock(final int value) {
         // given
-        final Product product = TestUtils.createProduct(5);
+        final Product product = DomainUtils.createProduct(5);
 
         // when
         final boolean result = product.canReduceStockBy(Quantity.from(value));
@@ -56,7 +56,7 @@ class ProductTest {
     void canReduceStock_manyQuantity() {
         // given
         final int stock = 5;
-        final Product product = TestUtils.createProduct(stock);
+        final Product product = DomainUtils.createProduct(stock);
 
         // when
         final boolean result = product.canReduceStockBy(Quantity.from(stock + 1));

--- a/src/test/java/com/gugucon/shopping/item/service/CartServiceTest.java
+++ b/src/test/java/com/gugucon/shopping/item/service/CartServiceTest.java
@@ -1,5 +1,11 @@
 package com.gugucon.shopping.item.service;
 
+import static com.gugucon.shopping.utils.DomainUtils.createProduct;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.gugucon.shopping.common.domain.vo.Quantity;
 import com.gugucon.shopping.item.domain.entity.CartItem;
 import com.gugucon.shopping.item.domain.entity.Product;
@@ -8,22 +14,15 @@ import com.gugucon.shopping.item.dto.request.CartItemUpdateRequest;
 import com.gugucon.shopping.item.dto.response.CartItemResponse;
 import com.gugucon.shopping.item.repository.CartItemRepository;
 import com.gugucon.shopping.item.repository.ProductRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static com.gugucon.shopping.TestUtils.createProduct;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CartService 단위 테스트")

--- a/src/test/java/com/gugucon/shopping/item/service/ProductServiceTest.java
+++ b/src/test/java/com/gugucon/shopping/item/service/ProductServiceTest.java
@@ -3,11 +3,11 @@ package com.gugucon.shopping.item.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.gugucon.shopping.TestUtils;
 import com.gugucon.shopping.common.dto.response.PagedResponse;
 import com.gugucon.shopping.item.domain.entity.Product;
 import com.gugucon.shopping.item.dto.response.ProductResponse;
 import com.gugucon.shopping.item.repository.ProductRepository;
+import com.gugucon.shopping.utils.DomainUtils;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,9 +36,9 @@ class ProductServiceTest {
         final Pageable pageable = PageRequest.of(0, 20, Direction.DESC, "createdAt");
 
         final List<Product> products = List.of(
-            TestUtils.createProduct("치킨", 20000),
-            TestUtils.createProduct("피자", 20000),
-            TestUtils.createProduct("사케", 30000)
+            DomainUtils.createProduct("치킨", 20000),
+            DomainUtils.createProduct("피자", 20000),
+            DomainUtils.createProduct("사케", 30000)
         );
         when(productRepository.findAll(pageable)).thenReturn(new PageImpl<>(products));
 

--- a/src/test/java/com/gugucon/shopping/order/domain/entity/OrderItemTest.java
+++ b/src/test/java/com/gugucon/shopping/order/domain/entity/OrderItemTest.java
@@ -1,15 +1,15 @@
 package com.gugucon.shopping.order.domain.entity;
 
-import com.gugucon.shopping.TestUtils;
-import com.gugucon.shopping.common.exception.ErrorCode;
-import com.gugucon.shopping.common.exception.ShoppingException;
-import com.gugucon.shopping.item.domain.entity.CartItem;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.gugucon.shopping.common.exception.ErrorCode;
+import com.gugucon.shopping.common.exception.ShoppingException;
+import com.gugucon.shopping.item.domain.entity.CartItem;
+import com.gugucon.shopping.utils.DomainUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 @DisplayName("OrderItem 단위 테스트")
 class OrderItemTest {
@@ -18,7 +18,7 @@ class OrderItemTest {
     @DisplayName("OrderItem을 생성한다.")
     void create() {
         // given
-        final CartItem cartItem = TestUtils.createCartItem();
+        final CartItem cartItem = DomainUtils.createCartItem();
 
         // when & then
         assertThatNoException().isThrownBy(() -> OrderItem.from(cartItem));
@@ -29,7 +29,7 @@ class OrderItemTest {
     void createFail_soldOutProduct() {
         // given
         final CartItem cartItem = CartItem.builder()
-                .product(TestUtils.createSoldOutProduct("name", 1000))
+                .product(DomainUtils.createSoldOutProduct("name", 1000))
                 .quantity(1)
                 .memberId(1L)
                 .build();
@@ -44,7 +44,7 @@ class OrderItemTest {
     void createFail_tooManyQuantity() {
         // given
         final CartItem cartItem = CartItem.builder()
-                .product(TestUtils.createProduct(1))
+                .product(DomainUtils.createProduct(1))
                 .quantity(2)
                 .memberId(1L)
                 .build();

--- a/src/test/java/com/gugucon/shopping/order/domain/entity/OrderTest.java
+++ b/src/test/java/com/gugucon/shopping/order/domain/entity/OrderTest.java
@@ -1,7 +1,7 @@
 package com.gugucon.shopping.order.domain.entity;
 
-import static com.gugucon.shopping.TestUtils.createMember;
-import static com.gugucon.shopping.TestUtils.createProduct;
+import static com.gugucon.shopping.utils.DomainUtils.createMember;
+import static com.gugucon.shopping.utils.DomainUtils.createProduct;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/com/gugucon/shopping/order/service/OrderServiceTest.java
+++ b/src/test/java/com/gugucon/shopping/order/service/OrderServiceTest.java
@@ -1,24 +1,23 @@
 package com.gugucon.shopping.order.service;
 
+import static com.gugucon.shopping.order.domain.entity.Order.OrderStatus.ORDERED;
+import static com.gugucon.shopping.utils.DomainUtils.createMember;
+import static com.gugucon.shopping.utils.DomainUtils.createProduct;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
 import com.gugucon.shopping.item.domain.entity.CartItem;
 import com.gugucon.shopping.item.repository.CartItemRepository;
 import com.gugucon.shopping.order.domain.entity.Order;
 import com.gugucon.shopping.order.repository.OrderRepository;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-
-import static com.gugucon.shopping.TestUtils.createMember;
-import static com.gugucon.shopping.TestUtils.createProduct;
-import static com.gugucon.shopping.order.domain.entity.Order.OrderStatus.ORDERED;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OrderService 단위 테스트")

--- a/src/test/java/com/gugucon/shopping/pay/infrastructure/DefaultCustomerKeyGeneratorTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/infrastructure/DefaultCustomerKeyGeneratorTest.java
@@ -1,11 +1,11 @@
 package com.gugucon.shopping.pay.infrastructure;
 
-import com.gugucon.shopping.TestUtils;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.gugucon.shopping.member.domain.entity.Member;
+import com.gugucon.shopping.utils.DomainUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("DefaultCustomerKeyGeneratorTest 단위 테스트")
 class DefaultCustomerKeyGeneratorTest {
@@ -16,7 +16,7 @@ class DefaultCustomerKeyGeneratorTest {
     @DisplayName("같은 회원에 대해 같은 키를 생성한다.")
     void generate_sameMember() {
         // given
-        final Member member = TestUtils.createMember();
+        final Member member = DomainUtils.createMember();
 
         // when
         final String keyA = customerKeyGenerator.generate(member);

--- a/src/test/java/com/gugucon/shopping/utils/ApiUtils.java
+++ b/src/test/java/com/gugucon/shopping/utils/ApiUtils.java
@@ -40,6 +40,17 @@ public class ApiUtils {
             .then().log().all();
     }
 
+    public static void signUp(final String email, final String password) {
+        final SignupRequest request = new SignupRequest(email, password, password,"testUser");
+        ApiUtils.signup(request);
+    }
+
+    public static String loginAfterSignUp(final String email, final String password) {
+        signUp(email, password);
+        final LoginRequest request = new LoginRequest(email, password);
+        return ApiUtils.login(request);
+    }
+
     public static ExtractableResponse<Response> insertCartItem(final String accessToken,
                                                                final CartItemInsertRequest cartItemInsertRequest) {
         return RestAssured

--- a/src/test/java/com/gugucon/shopping/utils/ApiUtils.java
+++ b/src/test/java/com/gugucon/shopping/utils/ApiUtils.java
@@ -1,0 +1,142 @@
+package com.gugucon.shopping.utils;
+
+import com.gugucon.shopping.item.dto.request.CartItemInsertRequest;
+import com.gugucon.shopping.item.dto.request.CartItemUpdateRequest;
+import com.gugucon.shopping.item.dto.response.CartItemResponse;
+import com.gugucon.shopping.member.dto.request.LoginRequest;
+import com.gugucon.shopping.member.dto.request.SignupRequest;
+import com.gugucon.shopping.member.dto.response.LoginResponse;
+import com.gugucon.shopping.pay.dto.request.PayCreateRequest;
+import com.gugucon.shopping.pay.dto.request.PayValidationRequest;
+import com.gugucon.shopping.pay.dto.response.PayCreateResponse;
+import com.gugucon.shopping.pay.dto.response.PayInfoResponse;
+import com.gugucon.shopping.pay.dto.response.PayValidationResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.springframework.http.MediaType;
+
+public class ApiUtils {
+
+    public static String login(final LoginRequest loginRequest) {
+        return RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(loginRequest)
+            .when().post("/api/v1/login/token")
+            .then().log().all()
+            .extract()
+            .as(LoginResponse.class)
+            .getAccessToken();
+    }
+
+    public static void signup(final SignupRequest signupRequest) {
+        RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(signupRequest)
+            .when().post("/api/v1/signup")
+            .then().log().all();
+    }
+
+    public static ExtractableResponse<Response> insertCartItem(final String accessToken,
+                                                               final CartItemInsertRequest cartItemInsertRequest) {
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(accessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(cartItemInsertRequest)
+            .when().post("/api/v1/cart/items")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> updateCartItem(final String accessToken,
+                                                               final long cartItemId,
+                                                               final CartItemUpdateRequest cartItemUpdateRequest) {
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(accessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(cartItemUpdateRequest)
+            .when().put("/api/v1/cart/items/{cartItemId}/quantity", cartItemId)
+            .then().log().all()
+            .extract();
+    }
+
+    public static List<CartItemResponse> readCartItems(final String accessToken) {
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(accessToken)
+            .when().get("/api/v1/cart/items")
+            .then().log().all()
+            .extract()
+            .jsonPath()
+            .getList(".", CartItemResponse.class);
+    }
+
+    public static Long placeOrder(final String accessToken) {
+        final ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .auth().oauth2(accessToken)
+            .when()
+            .post("/api/v1/order")
+            .then().log().all()
+            .extract();
+        return Long.parseLong(response.header("Location").split("/")[2]);
+    }
+
+    public static Long createPayment(final String accessToken, final PayCreateRequest payCreateRequest) {
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(accessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(payCreateRequest)
+            .when()
+            .put("/api/v1/pay")
+            .then().log().all()
+            .extract()
+            .as(PayCreateResponse.class)
+            .getPayId();
+    }
+
+    public static PayInfoResponse getPaymentInfo(final String accessToken, final Long payId) {
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(accessToken)
+            .when()
+            .get("/api/v1/pay/{payId}", payId)
+            .then().log().all()
+            .extract()
+            .as(PayInfoResponse.class);
+    }
+
+    public static Long validatePayment(final String accessToken, final PayValidationRequest payValidationRequest) {
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(accessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(payValidationRequest)
+            .when()
+            .post("/api/v1/pay/validate")
+            .then().log().all()
+            .extract()
+            .as(PayValidationResponse.class)
+            .getOrderId();
+    }
+
+    public static Long buyProduct(final String accessToken, final Long productId, final int quantity) {
+        insertCartItem(accessToken, new CartItemInsertRequest(productId));
+        final List<CartItemResponse> cartItemResponses = readCartItems(accessToken);
+        updateCartItem(accessToken, cartItemResponses.get(0).getCartItemId(), new CartItemUpdateRequest(quantity));
+        final Long orderId = placeOrder(accessToken);
+        final Long payId = createPayment(accessToken, new PayCreateRequest(orderId));
+        final PayInfoResponse payInfoResponse = getPaymentInfo(accessToken, payId);
+        final PayValidationRequest payValidationRequest = new PayValidationRequest("mockPaymentKey",
+                                                                                   payInfoResponse.getEncodedOrderId(),
+                                                                                   payInfoResponse.getPrice(),
+                                                                                   "mockPaymentType");
+        return validatePayment(accessToken, payValidationRequest);
+    }
+}

--- a/src/test/java/com/gugucon/shopping/utils/DomainUtils.java
+++ b/src/test/java/com/gugucon/shopping/utils/DomainUtils.java
@@ -1,4 +1,4 @@
-package com.gugucon.shopping;
+package com.gugucon.shopping.utils;
 
 import com.gugucon.shopping.item.domain.entity.CartItem;
 import com.gugucon.shopping.item.domain.entity.Product;
@@ -7,7 +7,7 @@ import com.gugucon.shopping.member.domain.vo.Password;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-public class TestUtils {
+public class DomainUtils {
 
     private static final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private static Long sequence = 0L;
@@ -67,6 +67,4 @@ public class TestUtils {
                 .quantity(1)
                 .build();
     }
-
-
 }


### PR DESCRIPTION
## 🔗 관련 이슈

#29 

## 🔔 주요 사항

- 테스트에서 반복적으로 호출되는 로그인 & 회원가입 과정을 유틸 메서드로 분리
- `TestUtils.java` 에 도메인 생성 로직과 api 호출 로직이 섞여있어 클래스 크기가 너무 커짐
  - `DomainUtils.java` 와 `ApiUtils.java` 로 분리

## 🤔 의논 사항 또는 질문

- 굳 ~

