### PR TITLE
fix: encodedOrderId 64자 이내로 제한

### DIFF
--- a/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64Translator.java
+++ b/src/main/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64Translator.java
@@ -12,6 +12,7 @@ import java.util.Base64.Encoder;
 public final class OrderIdBase64Translator implements OrderIdTranslator {
 
     private static final String DELIMITER = "--";
+    private static final int MAX_LENGTH = 64;
 
     private final Encoder encoder;
     private final Decoder decoder;
@@ -27,7 +28,15 @@ public final class OrderIdBase64Translator implements OrderIdTranslator {
                                           String.valueOf(order.getId()),
                                           order.createOrderName(),
                                           String.valueOf(LocalDateTime.now()));
-        return encoder.encodeToString(joined.getBytes());
+        final String encoded = encoder.encodeToString(joined.getBytes());
+        return limitLength(encoded);
+    }
+
+    private String limitLength(final String encoded) {
+        if (encoded.length() > MAX_LENGTH) {
+            return encoded.substring(0, MAX_LENGTH);
+        }
+        return encoded;
     }
 
     @Override

--- a/src/test/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64TranslatorTest.java
+++ b/src/test/java/com/gugucon/shopping/pay/infrastructure/OrderIdBase64TranslatorTest.java
@@ -3,6 +3,8 @@ package com.gugucon.shopping.pay.infrastructure;
 import com.gugucon.shopping.order.domain.entity.Order;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
@@ -12,12 +14,12 @@ class OrderIdBase64TranslatorTest {
 
     private final OrderIdTranslator orderIdTranslator = new OrderIdBase64Translator();
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "주문 이름", "검정 하이엔드 골져스 원더풀 레저 스틸 가죽 자켓"})
     @DisplayName("인코딩한 내용을 디코딩하면 같은 내용이 된다")
-    void encodeAndDecodeSuccess_SameString() {
+    void encodeAndDecodeSuccess_SameString(String orderName) {
         // given
-        Long orderId = 1L;
-        String orderName = "주문 이름";
+        Long orderId = 1_000_000L;
 
         final Order order = new Order() {
             @Override
@@ -50,5 +52,31 @@ class OrderIdBase64TranslatorTest {
 
         // then
         assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "주문 이름", "검정 하이엔드 골져스 원더풀 레저 스틸 가죽 자켓"})
+    @DisplayName("인코딩 후 길이가 6자 이상 64자 이내이다.")
+    void encodeSuccess_LimitFrom6To64(String orderName) {
+        // given
+        Long orderId = 1L;
+
+        final Order order = new Order() {
+            @Override
+            public Long getId() {
+                return orderId;
+            }
+
+            @Override
+            public String createOrderName() {
+                return orderName;
+            }
+        };
+
+        // when
+        String encodedString = orderIdTranslator.encode(order);
+
+        // then
+        assertThat(encodedString).hasSizeBetween(6, 64);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

#58 

## 🔔 주요 사항

- encodedOrderId 길이 제한 64자
- decode에 문제 없음 확인
- 프론트 E2E 테스트 확인

## 🤔 의논 사항 또는 질문

