### PR TITLE
build: Jacoco로 테스트 커버리지 측정

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -51,7 +51,7 @@ jobs:
       uses: madrapps/jacoco-report@v1.2
       with:
         title: 📝 테스트 커버리지 리포트입니다
-        paths: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+        paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -45,6 +45,15 @@ jobs:
       with:
         files: '**/build/test-results/test/TEST-*.xml'
 
+    - name: 테스트 커버리지를 PR에 코멘트로 등록합니다
+      if: always()
+      id: jacoco
+      uses: madrapps/jacoco-report@v1.2
+      with:
+        title: 📝 테스트 커버리지 리포트입니다
+        paths: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록
       uses: mikepenz/action-junit-report@v3
       if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.2'
     id 'io.spring.dependency-management' version '1.1.2'
+    id 'jacoco'
 }
 
 group = 'com.gugucon'
@@ -9,6 +10,22 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
+}
+
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn(test)
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+    }
 }
 
 configurations {


### PR DESCRIPTION
## 🔗 관련 이슈

#39 

## 🔔 주요 사항

- jacoco gradle에 추가
- ci workflow에서 pr에 테스트 커버리지 코멘트 추가 (제한 사항은 없게 함)

## 🤔 의논 사항 또는 질문

- 테스트 커버리지 파악하기..?
- 테스트 커버리지 보고싶으면 /build/jacoco/html/index.html 을 열어보시면 됩니다

