### PR TITLE
refactor: PayService 리팩토링

### DIFF
--- a/src/main/java/com/gugucon/shopping/order/service/OrderService.java
+++ b/src/main/java/com/gugucon/shopping/order/service/OrderService.java
@@ -1,27 +1,32 @@
 package com.gugucon.shopping.order.service;
 
+import com.gugucon.shopping.auth.dto.MemberPrincipal;
 import com.gugucon.shopping.common.dto.response.PagedResponse;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ShoppingException;
 import com.gugucon.shopping.item.domain.entity.CartItem;
 import com.gugucon.shopping.item.domain.entity.Product;
 import com.gugucon.shopping.item.repository.CartItemRepository;
+import com.gugucon.shopping.item.repository.OrderStatRepository;
 import com.gugucon.shopping.item.repository.ProductRepository;
+import com.gugucon.shopping.member.domain.vo.BirthYearRange;
 import com.gugucon.shopping.order.domain.PayType;
 import com.gugucon.shopping.order.domain.entity.Order;
+import com.gugucon.shopping.order.domain.entity.OrderItem;
 import com.gugucon.shopping.order.dto.request.OrderPayRequest;
 import com.gugucon.shopping.order.dto.response.OrderDetailResponse;
 import com.gugucon.shopping.order.dto.response.OrderHistoryResponse;
 import com.gugucon.shopping.order.dto.response.OrderPayResponse;
 import com.gugucon.shopping.order.dto.response.OrderResponse;
 import com.gugucon.shopping.order.repository.OrderRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -31,6 +36,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final CartItemRepository cartItemRepository;
     private final ProductRepository productRepository;
+    private final OrderStatRepository orderStatRepository;
 
     @Transactional
     public OrderResponse order(final Long memberId) {
@@ -41,6 +47,13 @@ public class OrderService {
 
         final Order order = Order.from(memberId, cartItems);
         return OrderResponse.from(orderRepository.save(order));
+    }
+
+    @Transactional
+    public void complete(final Order order, final MemberPrincipal principal) {
+        order.getOrderItems().forEach(orderItem -> updateOrderStatBy(principal, orderItem));
+        cartItemRepository.deleteAllByMemberId(principal.getId());
+        order.completePay();
     }
 
     public OrderDetailResponse getOrderDetail(final Long orderId, final Long memberId) {
@@ -56,6 +69,11 @@ public class OrderService {
                                                                               pageable);
 
         return convertToPage(orders);
+    }
+
+    public Order findOrderBy(final Long orderId, final Long memberId) {
+        return orderRepository.findByIdAndMemberId(orderId, memberId)
+                .orElseThrow(() -> new ShoppingException(ErrorCode.INVALID_ORDER));
     }
 
     private PagedResponse<OrderHistoryResponse> convertToPage(final Page<Order> orders) {
@@ -98,5 +116,12 @@ public class OrderService {
             product.validateStockIsNotLessThan(orderItem.getQuantity());
             product.decreaseStockBy(orderItem.getQuantity());
         });
+    }
+
+    private void updateOrderStatBy(final MemberPrincipal principal, final OrderItem orderItem) {
+        orderStatRepository.updateOrderStatByCount(orderItem.getQuantity().getValue(),
+                                                   orderItem.getProductId(),
+                                                   BirthYearRange.from(principal.getBirthDate()),
+                                                   principal.getGender());
     }
 }

--- a/src/main/java/com/gugucon/shopping/pay/service/PayService.java
+++ b/src/main/java/com/gugucon/shopping/pay/service/PayService.java
@@ -4,12 +4,8 @@ import com.gugucon.shopping.auth.dto.MemberPrincipal;
 import com.gugucon.shopping.common.domain.vo.Money;
 import com.gugucon.shopping.common.exception.ErrorCode;
 import com.gugucon.shopping.common.exception.ShoppingException;
-import com.gugucon.shopping.item.repository.CartItemRepository;
-import com.gugucon.shopping.item.repository.OrderStatRepository;
-import com.gugucon.shopping.member.domain.vo.BirthYearRange;
 import com.gugucon.shopping.order.domain.entity.Order;
-import com.gugucon.shopping.order.domain.entity.OrderItem;
-import com.gugucon.shopping.order.repository.OrderRepository;
+import com.gugucon.shopping.order.service.OrderService;
 import com.gugucon.shopping.pay.config.TossPayConfiguration;
 import com.gugucon.shopping.pay.domain.Pay;
 import com.gugucon.shopping.pay.dto.request.PointPayRequest;
@@ -32,24 +28,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class PayService {
 
     private final PayRepository payRepository;
-    private final OrderRepository orderRepository;
-    private final CartItemRepository cartItemRepository;
     private final PointRepository pointRepository;
     private final TossPayProvider tossPayProvider;
     private final TossPayConfiguration tossPayConfiguration;
-    private final OrderStatRepository orderStatRepository;
+    private final OrderService orderService;
 
     @Transactional
     public PayResponse payByPoint(final PointPayRequest pointPayRequest, final MemberPrincipal principal) {
         final Long orderId = pointPayRequest.getOrderId();
         final Long memberId = principal.getId();
-        final Order order = findOrderBy(orderId, memberId);
+        final Order order = orderService.findOrderBy(orderId, memberId);
 
         final Point point = findPointBy(memberId);
         point.use(order.calculateTotalPrice());
-        order.getOrderItems().forEach(orderItem -> updateOrderStatBy(principal, orderItem));
+        orderService.complete(order, principal);
 
-        return completePay(memberId, order);
+        return PayResponse.from(payRepository.save(Pay.from(order)));
     }
 
     private Point findPointBy(final Long memberId) {
@@ -58,7 +52,7 @@ public class PayService {
     }
 
     public TossPayInfoResponse getTossInfo(final Long orderId, final Long memberId) {
-        final Order order = findOrderBy(orderId, memberId);
+        final Order order = orderService.findOrderBy(orderId, memberId);
 
         return TossPayInfoResponse.from(tossPayProvider.encodeOrderId(order.getId(), order.createOrderName()),
                                         order,
@@ -71,31 +65,14 @@ public class PayService {
     public PayResponse payByToss(final TossPayRequest tossPayRequest, final MemberPrincipal principal) {
         final Long orderId = tossPayProvider.decodeOrderId(tossPayRequest.getOrderId());
         final Long memberId = principal.getId();
-        final Order order = findOrderBy(orderId, memberId);
+        final Order order = orderService.findOrderBy(orderId, memberId);
 
         order.validateMoney(Money.from(tossPayRequest.getAmount()));
-        order.getOrderItems().forEach(orderItem -> updateOrderStatBy(principal, orderItem));
+        orderService.complete(order, principal);
+        final Pay pay = payRepository.save(Pay.from(order));
         tossPayProvider.validatePayment(tossPayRequest);
 
-        return completePay(memberId, order);
-    }
-
-    private PayResponse completePay(final Long memberId, final Order order) {
-        cartItemRepository.deleteAllByMemberId(memberId);
-        order.completePay();
-        return PayResponse.from(payRepository.save(Pay.from(order)));
-    }
-
-    private void updateOrderStatBy(final MemberPrincipal principal, final OrderItem orderItem) {
-        orderStatRepository.updateOrderStatByCount(orderItem.getQuantity().getValue(),
-                                                   orderItem.getProductId(),
-                                                   BirthYearRange.from(principal.getBirthDate()),
-                                                   principal.getGender());
-    }
-
-    private Order findOrderBy(final Long orderId, final Long memberId) {
-        return orderRepository.findByIdAndMemberId(orderId, memberId)
-                .orElseThrow(() -> new ShoppingException(ErrorCode.INVALID_ORDER));
+        return PayResponse.from(pay);
     }
 
     public TossPayFailResponse decodeOrderId(final TossPayFailRequest tossPayFailRequest) {


### PR DESCRIPTION
## 🔗 관련 이슈

#138 
#141 

## 🔔 주요 사항

- `PayService`에서 `CartItemRepository`, `OrderStatRepository`, `OrderRepository` 의존성을 제거하고 `OrderService`를 의존하도록 변경
- `payByToss`의 경우 외부 API 호출 로직을 메서드 마지막으로 옮겨서 결제 완료 후 트랜잭션이 롤백될 가능성을 최소화함

